### PR TITLE
Update package scope from @arkahna to @arkahna-npm for npm publishing

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
-store-dir=./.pnpm-store
-shamefully-hoist=false
-prefer-symlinked-executables=false
+registry=https://registry.npmjs.org/
+@arkahna-npm:registry=https://registry.npmjs.org/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # git-file-fetch
 
 [![CI](https://github.com/arkahna/git-file-fetch/actions/workflows/ci.yml/badge.svg)](https://github.com/arkahna/git-file-fetch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/@arkahna/git-file-fetch)](https://www.npmjs.com/package/@arkahna/git-file-fetch)
+[![npm version](https://img.shields.io/npm/v/@arkahna-npm/git-file-fetch)](https://www.npmjs.com/package/@arkahna-npm/git-file-fetch)
 [![license: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 [![node >= 20](https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg)](#requirements)
 
@@ -11,13 +11,13 @@ A lightweight CLI to fetch individual files from remote Git repositories and tra
 
 ### 🚀 **Just want to use it?**
 ```bash
-npx @arkahna/git-file-fetch "https://github.com/user/repo.git@main:path/to/file.ts"
+npx @arkahna-npm/git-file-fetch "https://github.com/user/repo.git@main:path/to/file.ts"
 ```
 
 ### 📦 **Want to install it?**
 ```bash
-npm install -D @arkahna/git-file-fetch
-npx @arkahna/git-file-fetch "https://github.com/user/repo.git@main:path/to/file.ts"
+npm install -D @arkahna-npm/git-file-fetch
+npx @arkahna-npm/git-file-fetch "https://github.com/user/repo.git@main:path/to/file.ts"
 ```
 
 ### 🔧 **Want to test/develop it?**

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@arkahna/git-file-fetch",
+  "name": "@arkahna-npm/git-file-fetch",
   "version": "0.1.0",
   "description": "Fetch specific files from remote git repos and track them locally.",
   "main": "dist/index.js",
@@ -58,7 +58,7 @@
     "dist",
     "plugin"
   ],
-  "packageManager": "pnpm@10.15.1+sha512.34e538c329b5553014ca8e8f4535997f96180a1d0f614339357449935350d924e22f8614682191264ec33d1462ac21561aff97f6bb18065351c162c7e8f6de67",
+  "packageManager": "pnpm@10.17.1+sha512.17c560fca4867ae9473a3899ad84a88334914f379be46d455cbf92e5cf4b39d34985d452d2583baf19967fa76cb5c17bc9e245529d0b98745721aa7200ecaf7a",
   "publishConfig": {
     "access": "public",
     "provenance": true


### PR DESCRIPTION
### Summary
Updated the package scope to @arkahna-npm since the @arkahna organisation name was not available on npm. This change enables successful publishing to the npm registry.

### Changes
- [x] Feature
- [ ] Bug fix
- [x] Docs
- [ ] CI/Chore

### Checklist
- [x] Lint passes (`pnpm lint:check`)
- [x] Types compile (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Tests pass (if added)
- [x] Docs/README updated

