### PR TITLE
chore: update pnpm version and enhance README with local testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ git clone https://github.com/arkahna/git-file-fetch.git
 cd git-file-fetch
 pnpm install
 pnpm build
-node dist/index.js "https://github.com/octokit/core.js.git@main:LICENSE" --dry-run
 ```
 
 **Available development commands:**
@@ -35,6 +34,45 @@ node dist/index.js "https://github.com/octokit/core.js.git@main:LICENSE" --dry-r
 - `pnpm lint:check` - Run ESLint checks
 - `pnpm lint` - Run ESLint with auto-fix
 - `pnpm test:smoke` - Run smoke test
+
+## Local Testing (Before npm Publish)
+
+### Option 1: Link Globally (Recommended)
+Test the tool as if it were installed from npm:
+```bash
+# In the git-file-fetch directory
+pnpm install
+pnpm build
+npm link
+
+# Now use from anywhere on your system
+git-file-fetch "https://github.com/octokit/core.js.git@main:LICENSE"
+
+# To unlink later
+npm unlink -g @arkahna-npm/git-file-fetch
+```
+
+### Option 2: Direct Execution
+Quick testing during development:
+```bash
+# Using built version
+node dist/index.js "https://github.com/octokit/core.js.git@main:LICENSE" --dry-run
+
+# Or run TypeScript directly (no build needed)
+pnpm start "https://github.com/octokit/core.js.git@main:LICENSE" --dry-run
+```
+
+### Option 3: Test in Another Project
+Most realistic test of the published package:
+```bash
+# In git-file-fetch directory
+pnpm pack
+# Creates: arkahna-npm-git-file-fetch-0.1.0.tgz
+
+# In your test project
+npm install /path/to/git-file-fetch/arkahna-npm-git-file-fetch-0.1.0.tgz
+npx git-file-fetch "https://github.com/user/repo.git@main:file.ts"
+```
 
 ## What it does
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "dist",
     "plugin"
   ],
-  "packageManager": "pnpm@10.17.1+sha512.17c560fca4867ae9473a3899ad84a88334914f379be46d455cbf92e5cf4b39d34985d452d2583baf19967fa76cb5c17bc9e245529d0b98745721aa7200ecaf7a",
+  "packageManager": "pnpm@10.18.1+sha512.77a884a165cbba2d8d1c19e3b4880eee6d2fcabd0d879121e282196b80042351d5eb3ca0935fa599da1dc51265cc68816ad2bddd2a2de5ea9fdf92adbec7cd34",
   "publishConfig": {
     "access": "public",
     "provenance": true


### PR DESCRIPTION
### Summary
Update package manager version and enhance README with local testing instructions
- Bumped package manager version in package.json to pnpm@10.18.1.
- Added detailed local testing options in README for better developer experience.

### Changes
- [ ] Feature
- [ ] Bug fix
- [X] Docs
- [X] CI/Chore

### Checklist
- [X] Lint passes (`pnpm lint:check`)
- [X] Types compile (`pnpm typecheck`)
- [X] Build succeeds (`pnpm build`)
- [X] Tests pass (if added)
- [X] Docs/README updated

