### PR TITLE
refactor: remove Arkahna branding and prepare for npm publishing

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 registry=https://registry.npmjs.org/
-@arkahna-npm:registry=https://registry.npmjs.org/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Initial release of `@arkahna/git-file-fetch` CLI
+- Initial release of `git-file-fetch` CLI
 - Support for fetching single/multiple files from remote Git repositories
 - Shallow Git operations without full repository cloning
 - Manifest tracking via `.git-remote-files.json`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-`@arkahna/git-file-fetch` is a TypeScript CLI tool that fetches individual files from remote Git repositories without cloning. It uses shallow Git operations and maintains a manifest file (`.git-remote-files.json`) to track fetched files.
+`git-file-fetch` is a TypeScript CLI tool that fetches individual files from remote Git repositories without cloning. It uses shallow Git operations and maintains a manifest file (`.git-remote-files.json`) to track fetched files.
 
 ## Requirements
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Arkahna
+Copyright (c) 2025 Joshua Boys
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the “Software”), to deal

--- a/README.md
+++ b/README.md
@@ -1,92 +1,31 @@
 # git-file-fetch
 
-[![CI](https://github.com/arkahna/git-file-fetch/actions/workflows/ci.yml/badge.svg)](https://github.com/arkahna/git-file-fetch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/@arkahna-npm/git-file-fetch)](https://www.npmjs.com/package/@arkahna-npm/git-file-fetch)
+[![CI](https://github.com/joshuaboys/git-file-fetch/actions/workflows/ci.yml/badge.svg)](https://github.com/joshuaboys/git-file-fetch/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/git-file-fetch)](https://www.npmjs.com/package/git-file-fetch)
 [![license: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 [![node >= 22](https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg)](#requirements)
 
 A lightweight CLI to fetch individual files from remote Git repositories and track them locally for reproducibility.
 
-> **⚠️ NOT YET PUBLISHED TO NPM**
-> This package is pending its initial npm release. Until then, use the local testing methods below to try it out.
+## Quick Start
 
-## 🧪 Local Testing (Pre-Release)
-
-The package is not yet available on npm. Here's how to test it locally:
-
-### Option 1: Link Globally (Recommended)
-
-Test the tool as if it were installed from npm:
+### Just want to use it?
 
 ```bash
-# Clone and setup
-git clone https://github.com/arkahna/git-file-fetch.git
-cd git-file-fetch
-pnpm install
-pnpm build
-npm link
-
-# Now use from anywhere on your system
-git-file-fetch "https://github.com/octokit/core.js.git@main:LICENSE"
-
-# To unlink later
-npm unlink -g @arkahna-npm/git-file-fetch
+npx git-file-fetch "https://github.com/user/repo.git@main:path/to/file.ts"
 ```
 
-### Option 2: Direct Execution
-
-Quick testing during development:
+### Want to install it?
 
 ```bash
-# Clone and setup
-git clone https://github.com/arkahna/git-file-fetch.git
-cd git-file-fetch
-pnpm install
-pnpm build
-
-# Using built version
-node dist/index.js "https://github.com/octokit/core.js.git@main:LICENSE" --dry-run
-
-# Or run TypeScript directly (no build needed)
-pnpm start "https://github.com/octokit/core.js.git@main:LICENSE" --dry-run
+npm install -D git-file-fetch
+npx git-file-fetch "https://github.com/user/repo.git@main:path/to/file.ts"
 ```
 
-### Option 3: Test in Another Project
-
-Most realistic test of the published package:
+### Want to contribute/develop?
 
 ```bash
-# In git-file-fetch directory
-pnpm install
-pnpm pack
-# Creates: arkahna-npm-git-file-fetch-0.1.0.tgz
-
-# In your test project
-npm install /path/to/git-file-fetch/arkahna-npm-git-file-fetch-0.1.0.tgz
-npx git-file-fetch "https://github.com/user/repo.git@main:file.ts"
-```
-
----
-
-## Quick Start (After npm Release)
-
-### 🚀 **Just want to use it?**
-
-```bash
-npx @arkahna-npm/git-file-fetch "https://github.com/user/repo.git@main:path/to/file.ts"
-```
-
-### 📦 **Want to install it?**
-
-```bash
-npm install -D @arkahna-npm/git-file-fetch
-npx @arkahna-npm/git-file-fetch "https://github.com/user/repo.git@main:path/to/file.ts"
-```
-
-### 🔧 **Want to contribute/develop?**
-
-```bash
-git clone https://github.com/arkahna/git-file-fetch.git
+git clone https://github.com/joshuaboys/git-file-fetch.git
 cd git-file-fetch
 pnpm install
 pnpm build
@@ -96,10 +35,7 @@ pnpm build
 
 - `pnpm build` - Build the project
 - `pnpm typecheck` - Run TypeScript type checking
-- `pnpm lint:check` - Run ESLint checks
-- `pnpm lint:fix` - Run ESLint with auto-fix
-- `pnpm lint:md` - Run Markdown lint checks
-- `pnpm lint:md:fix` - Run Markdown lint with auto-fix
+- `pnpm lint` - Run ESLint with auto-fix
 - `pnpm test:smoke` - Run smoke test
 
 ## What it does
@@ -111,15 +47,15 @@ pnpm build
 
 ## Documentation
 
-- 🚀 [Getting Started](docs/getting-started.md) - Complete setup guide
-- 📖 [Usage Guide](docs/usage.md) - CLI options and examples
-- ⚙️ [Configuration](docs/configuration.md) - Advanced setup
-- 🔧 [Troubleshooting](docs/troubleshooting.md) - Common issues
-- 🚀 [CI Integration](docs/ci-integration.md) - CI/CD workflows and automation
-- 🛣️ [Roadmap](docs/roadmap.md) - Development plans
-- 🤝 [Contributing](docs/contributing.md) - How to contribute
-- 🔒 [Security](docs/security.md) - Security policies
-- 📋 [Code of Conduct](docs/code-of-conduct.md) - Community guidelines
+- [Getting Started](docs/getting-started.md) - Complete setup guide
+- [Usage Guide](docs/usage.md) - CLI options and examples
+- [Configuration](docs/configuration.md) - Advanced setup
+- [Troubleshooting](docs/troubleshooting.md) - Common issues
+- [CI Integration](docs/ci-integration.md) - CI/CD workflows and automation
+- [Roadmap](docs/roadmap.md) - Development plans
+- [Contributing](docs/contributing.md) - How to contribute
+- [Security](docs/security.md) - Security policies
+- [Code of Conduct](docs/code-of-conduct.md) - Community guidelines
 
 ## Requirements
 
@@ -128,9 +64,11 @@ pnpm build
 
 ## License
 
-MIT © Arkahna
+MIT © Joshua Boys
 
-## Originally contributed by [Aneki](https://github.com/joshuaboys)
+## Author
+
+Created by [Joshua Boys](https://github.com/joshuaboys)
 
 ```text
                   _    _

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
-// @arkahna/git-file-fetch
+// git-file-fetch
 // Fetch specific file(s) from remote Git repos and drop them into your project.
 // Tracks origin in .git-remote-files.json for reproducibility.
+const VERSION = '0.1.0';
 import { execFileSync } from 'child_process';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join, dirname, resolve, sep, posix as pathPosix } from 'path';
@@ -41,10 +42,10 @@ function createLogger(quiet, verbose) {
 }
 function printHelp() {
     const usage = `
-@arkahna/git-file-fetch
+git-file-fetch v${VERSION}
 
 Usage:
-  @arkahna/git-file-fetch '<repo.git>@<ref>:<path>' [more...] [--dry-run] [--force] [--out <dir>] [--cwd <dir>] [--manifest <path>] [--max-bytes <n>] [--config <file>] [--timeout-ms <n>] [--retries <n>] [--retry-backoff-ms <n>] [--eject] [--json] [--quiet] [--verbose]
+  git-file-fetch '<repo.git>@<ref>:<path>' [more...] [--dry-run] [--force] [--out <dir>] [--cwd <dir>] [--manifest <path>] [--max-bytes <n>] [--config <file>] [--timeout-ms <n>] [--retries <n>] [--retry-backoff-ms <n>] [--eject] [--json] [--quiet] [--verbose]
 
 Options:
   --dry-run           Simulate only; do not write files or update the manifest
@@ -61,13 +62,14 @@ Options:
   --json              Machine-readable JSON output with per-item results
   --quiet             Suppress normal logs (errors still printed)
   --verbose           Print verbose logs for debugging
+  -v, --version       Show version number and exit
   -h, --help          Show this help and exit
 
 Examples:
-  npx @arkahna/git-file-fetch "https://github.com/user/repo.git@main:src/utils/logger.ts"
-  npx @arkahna/git-file-fetch "https://github.com/user/repo.git@v1.2.3:LICENSE" --force
-  npx @arkahna/git-file-fetch --out third_party "https://github.com/user/repo.git@main:tools/script.sh"
-  npx @arkahna/git-file-fetch --config refs.json --out vendor --json
+  npx git-file-fetch "https://github.com/user/repo.git@main:src/utils/logger.ts"
+  npx git-file-fetch "https://github.com/user/repo.git@v1.2.3:LICENSE" --force
+  npx git-file-fetch --out third_party "https://github.com/user/repo.git@main:tools/script.sh"
+  npx git-file-fetch --config refs.json --out vendor --json
 
 Exit codes:
   0  Success
@@ -158,7 +160,7 @@ function updateManifest(manifestPath, remote) {
     writeFileSync(manifestPath, JSON.stringify(existing, null, 2));
 }
 function fsTempDir() {
-    const dir = join(tmpdir(), `arkahna-git-file-fetch-${Date.now()}`);
+    const dir = join(tmpdir(), `git-file-fetch-${Date.now()}`);
     mkdirSync(dir);
     return dir;
 }
@@ -345,6 +347,7 @@ function fetchFileMinimal(remote, tempDir, timeoutMs, retries, backoffMs, logger
 function main() {
     const argv = process.argv.slice(2);
     const showHelp = argv.includes('-h') || argv.includes('--help');
+    const showVersion = argv.includes('-v') || argv.includes('--version');
     const dryRun = argv.includes('--dry-run');
     const force = argv.includes('--force');
     const jsonOutput = argv.includes('--json');
@@ -395,6 +398,10 @@ function main() {
         ? parseInt(backoffFlag, 10)
         : (envBackoff ?? 500);
     const configFlag = getFlagValue(argv, 'config');
+    if (showVersion) {
+        console.log(VERSION);
+        process.exit(0);
+    }
     if (showHelp) {
         printHelp();
         process.exit(0);

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -1,10 +1,10 @@
 # CI Integration
 
-This guide covers how to integrate `@arkahna/git-file-fetch` into your CI/CD pipelines for automated file fetching and verification.
+This guide covers how to integrate `git-file-fetch` into your CI/CD pipelines for automated file fetching and verification.
 
 ## Overview
 
-`@arkahna/git-file-fetch` is designed to work seamlessly in CI environments, providing:
+`git-file-fetch` is designed to work seamlessly in CI environments, providing:
 
 - **Reproducible builds** through manifest tracking
 - **Dry-run verification** without file modifications
@@ -32,7 +32,7 @@ jobs:
       
       - name: Verify external files
         run: |
-          npx @arkahna/git-file-fetch \
+          npx git-file-fetch \
             "https://github.com/octokit/core.js.git@main:LICENSE" \
             "https://github.com/microsoft/TypeScript.git@main:README.md" \
             --dry-run \
@@ -48,7 +48,7 @@ verify:
   before_script:
     - apk add --no-cache git
   script:
-    - npx @arkahna/git-file-fetch "https://github.com/user/repo.git@main:src/config.json" --dry-run
+    - npx git-file-fetch "https://github.com/user/repo.git@main:src/config.json" --dry-run
 ```
 
 ### Jenkins Pipeline
@@ -60,7 +60,7 @@ pipeline {
         stage('Verify Dependencies') {
             steps {
                 sh '''
-                    npx @arkahna/git-file-fetch \\
+                    npx git-file-fetch \\
                         "https://github.com/user/repo.git@main:src/utils.ts" \\
                         --dry-run \\
                         --json
@@ -81,7 +81,7 @@ Verify that external files haven't changed unexpectedly:
 - name: Verify external dependencies
   run: |
     # Fetch files and compare with manifest
-    npx @arkahna/git-file-fetch --config deps.json --dry-run --json > verification.json
+    npx git-file-fetch --config deps.json --dry-run --json > verification.json
     
     # Check if any files have changed
     if jq -e '.results[] | select(.status != "unchanged")' verification.json; then
@@ -111,7 +111,7 @@ jobs:
       
       - name: Update external files
         run: |
-          npx @arkahna/git-file-fetch --config deps.json --out third_party
+          npx git-file-fetch --config deps.json --out third_party
       
       - name: Commit changes
         run: |
@@ -143,7 +143,7 @@ jobs:
       
       - name: Test with ${{ matrix.environment }} config
         run: |
-          npx @arkahna/git-file-fetch \
+          npx git-file-fetch \
             --config configs/${{ matrix.environment }}.json \
             --dry-run \
             --json
@@ -186,7 +186,7 @@ jobs:
 Always use `--dry-run` in CI to verify files without modifying your repository:
 
 ```bash
-npx @arkahna/git-file-fetch --config deps.json --dry-run --json
+npx git-file-fetch --config deps.json --dry-run --json
 ```
 
 ### 2. Commit the Manifest
@@ -205,7 +205,7 @@ Configure timeouts for network operations in CI:
 ```bash
 export FETCH_GIT_FILE_TIMEOUT_MS=30000  # 30 seconds
 export FETCH_GIT_FILE_RETRIES=3
-npx @arkahna/git-file-fetch --config deps.json
+npx git-file-fetch --config deps.json
 ```
 
 ### 4. Use JSON Output for Automation
@@ -213,7 +213,7 @@ npx @arkahna/git-file-fetch --config deps.json
 Parse JSON output for programmatic handling:
 
 ```bash
-npx @arkahna/git-file-fetch --config deps.json --json | jq '.results[] | select(.status == "error")'
+npx git-file-fetch --config deps.json --json | jq '.results[] | select(.status == "error")'
 ```
 
 ### 5. Handle Authentication
@@ -225,7 +225,7 @@ For private repositories, use appropriate authentication:
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   run: |
-    npx @arkahna/git-file-fetch \
+    npx git-file-fetch \
       "https://github.com/org/private-repo.git@main:src/config.json" \
       --dry-run
 ```
@@ -250,7 +250,7 @@ For private repositories, use appropriate authentication:
 Enable verbose output for troubleshooting:
 
 ```bash
-npx @arkahna/git-file-fetch --config deps.json --verbose --dry-run
+npx git-file-fetch --config deps.json --verbose --dry-run
 ```
 
 ## Security Considerations
@@ -262,4 +262,4 @@ npx @arkahna/git-file-fetch --config deps.json --verbose --dry-run
 
 ## Examples Repository
 
-See [examples/ci-workflows](https://github.com/arkahna/git-file-fetch/tree/main/examples/ci-workflows) for complete working examples of various CI integrations.
+See [examples/ci-workflows](https://github.com/joshuaboys/git-file-fetch/tree/main/examples/ci-workflows) for complete working examples of various CI integrations.

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -5,6 +5,6 @@ This project follows the Contributor Covenant Code of Conduct.
 - Homepage: [https://www.contributor-covenant.org](https://www.contributor-covenant.org)
 - Version: 2.1
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainers at [security@arkahna.io](mailto:security@arkahna.io). All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported via [GitHub Issues](https://github.com/joshuaboys/git-file-fetch/issues) or by contacting the maintainer directly. All complaints will be reviewed and investigated promptly and fairly.
 
 Attribution: This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@
 The simplest way to configure the tool is through command line arguments:
 
 ```bash
-npx @arkahna/git-file-fetch "https://github.com/user/repo.git@main:src/file.ts"
+npx git-file-fetch "https://github.com/user/repo.git@main:src/file.ts"
 ```
 
 ### 2. Configuration Files
@@ -19,7 +19,7 @@ npx @arkahna/git-file-fetch "https://github.com/user/repo.git@main:src/file.ts"
 For multiple files or complex setups, use the `--config` option with a JSON file:
 
 ```bash
-npx @arkahna/git-file-fetch --config refs.json --out vendor
+npx git-file-fetch --config refs.json --out vendor
 ```
 
 ### 3. Environment Variables
@@ -29,7 +29,7 @@ Configure behavior through environment variables:
 ```bash
 export FETCH_GIT_FILE_MAX_BYTES=5000000  # 5MB limit
 export FETCH_GIT_FILE_TIMEOUT_MS=30000   # 30 second timeout
-npx @arkahna/git-file-fetch "https://github.com/user/repo.git@main:file.txt"
+npx git-file-fetch "https://github.com/user/repo.git@main:file.txt"
 ```
 
 ## Configuration File Format
@@ -125,7 +125,7 @@ This keeps the manifest local to your development environment.
 Override the default manifest location:
 
 ```bash
-npx @arkahna/git-file-fetch \
+npx git-file-fetch \
   --manifest ./config/external-files.json \
   "https://github.com/user/repo.git@main:file.txt"
 ```
@@ -137,7 +137,7 @@ npx @arkahna/git-file-fetch \
 Specify where fetched files should be placed:
 
 ```bash
-npx @arkahna/git-file-fetch \
+npx git-file-fetch \
   --out ./third_party \
   "https://github.com/user/repo.git@main:src/file.ts"
 ```
@@ -147,7 +147,7 @@ npx @arkahna/git-file-fetch \
 Change the working directory before running:
 
 ```bash
-npx @arkahna/git-file-fetch \
+npx git-file-fetch \
   --cwd ./subproject \
   --out ./deps \
   "https://github.com/user/repo.git@main:file.txt"
@@ -160,7 +160,7 @@ npx @arkahna/git-file-fetch \
 Configure network behavior:
 
 ```bash
-npx @arkahna/git-file-fetch \
+npx git-file-fetch \
   --timeout-ms 30000 \
   --retries 3 \
   --retry-backoff-ms 1000 \
@@ -195,7 +195,7 @@ jobs:
         with:
           node-version: 22
       - run: |
-          npx @arkahna/git-file-fetch \
+          npx git-file-fetch \
             --config deps.json \
             --out third_party \
             --json \
@@ -208,7 +208,7 @@ jobs:
 fetch-deps:
   image: node:22
   script:
-    - npx @arkahna/git-file-fetch --config deps.json --out third_party --json
+    - npx git-file-fetch --config deps.json --out third_party --json
   artifacts:
     paths:
       - third_party/

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@
 You can run it directly with npx without installing anything:
 
 ```bash
-npx @arkahna/git-file-fetch "https://github.com/user/repo.git@main:path/to/file.ts"
+npx git-file-fetch "https://github.com/user/repo.git@main:path/to/file.ts"
 ```
 
 ### Option 2: Install as a dependency (recommended for projects)
@@ -25,30 +25,28 @@ Add it to your project for consistent versioning:
 
 ```bash
 # Using npm
-npm install -D @arkahna/git-file-fetch
+npm install -D git-file-fetch
 
 # Using pnpm
-pnpm add -D @arkahna/git-file-fetch
+pnpm add -D git-file-fetch
 
 # Using yarn
-yarn add -D @arkahna/git-file-fetch
+yarn add -D git-file-fetch
 ```
 
 Then run:
 
 ```bash
-npx @arkahna/git-file-fetch "https://github.com/user/repo.git@main:path/to/file.ts"
+npx git-file-fetch "https://github.com/user/repo.git@main:path/to/file.ts"
 ```
 
 ### Option 3: Test the project locally
-
-*This is the only option currently available for testing the project before it's published to npm.*
 
 If you're developing or want to test the project:
 
 ```bash
 # Clone and setup
-git clone https://github.com/arkahna/git-file-fetch.git
+git clone https://github.com/joshuaboys/git-file-fetch.git
 cd git-file-fetch
 pnpm install
 
@@ -128,7 +126,7 @@ This package includes a thin Nx executor for Nx workspaces:
 {
   "targets": {
     "fetch": {
-      "executor": "@arkahna/git-file-fetch:fetch",
+      "executor": "git-file-fetch:fetch",
       "options": {
         "args": "https://github.com/user/repo.git@main:src/utils/logger.ts"
       }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -98,7 +98,7 @@ We're currently in the final stages of preparation before our first npm release.
 
 ### Phase 4 TODO Checklist
 
-- [ ] **Executor Package**: Spin out `@arkahna/nx-git-file-fetch` executor + `nx add` generator
+- [ ] **Executor Package**: Spin out `nx-git-file-fetch` executor + `nx add` generator
 - [ ] **Example Workspace**: Create E2E example workspace + docs (include CI usage)
 - [ ] **Caching Config**: Add caching config for outputs if you add `update`/`verify` targets
 - [ ] **Release Automation**: Version alignment and release automation between core and plugin
@@ -239,4 +239,4 @@ Recommended labels for tracking work:
 
 ---
 
-*This roadmap is a living document and will be updated as we progress through development phases. For the latest status, check our [GitHub Issues](https://github.com/arkahna/git-file-fetch/issues) and [Releases](https://github.com/arkahna/git-file-fetch/releases).*
+*This roadmap is a living document and will be updated as we progress through development phases. For the latest status, check our [GitHub Issues](https://github.com/joshuaboys/git-file-fetch/issues) and [Releases](https://github.com/joshuaboys/git-file-fetch/releases).*

--- a/docs/security.md
+++ b/docs/security.md
@@ -6,7 +6,8 @@ We aim to support the current and previous Node.js LTS versions for the CLI. Old
 
 ## Reporting a Vulnerability
 
-- Email: [security@arkahna.io](mailto:security@arkahna.io)
+- Open a [security advisory on GitHub](https://github.com/joshuaboys/git-file-fetch/security/advisories/new)
+- Or email the maintainer directly via GitHub profile contact
 - Please provide details to reproduce, affected versions, and potential impact.
 - Do not create a public issue for sensitive reports.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,7 +3,7 @@
 ## CLI Synopsis
 
 ```bash
-@arkahna-npm/git-file-fetch '<repo.git>@<ref>:<path>' [more...] [--dry-run] [--force] [--out <dir>] [--cwd <dir>] [--manifest <path>] [--max-bytes <n>] [--config <file>] [--timeout-ms <n>] [--retries <n>] [--retry-backoff-ms <n>] [--eject] [--json] [--quiet] [--verbose]
+git-file-fetch '<repo.git>@<ref>:<path>' [more...] [--dry-run] [--force] [--out <dir>] [--cwd <dir>] [--manifest <path>] [--max-bytes <n>] [--config <file>] [--timeout-ms <n>] [--retries <n>] [--retry-backoff-ms <n>] [--eject] [--json] [--quiet] [--verbose]
 ```
 
 ## Command Line Options
@@ -65,22 +65,22 @@ https://github.com/user/repo.git:src/config.json
 
 ```bash
 # Fetch a single file
-npx @arkahna-npm/git-file-fetch "https://github.com/user/repo.git@main:src/utils/logger.ts"
+npx git-file-fetch "https://github.com/user/repo.git@main:src/utils/logger.ts"
 
 # Fetch with specific tag
-npx @arkahna-npm/git-file-fetch "https://github.com/user/repo.git@v1.2.3:LICENSE"
+npx git-file-fetch "https://github.com/user/repo.git@v1.2.3:LICENSE"
 
 # Eject: copy the file without adding to manifest
-npx @arkahna-npm/git-file-fetch "https://github.com/user/repo.git@main:src/utils/logger.ts" --eject
+npx git-file-fetch "https://github.com/user/repo.git@main:src/utils/logger.ts" --eject
 
 # Dry run (simulate without writing files)
-npx @arkahna-npm/git-file-fetch "https://github.com/user/repo.git@main:src/file.ts" --dry-run
+npx git-file-fetch "https://github.com/user/repo.git@main:src/file.ts" --dry-run
 
 # Specify output directory
-npx @arkahna-npm/git-file-fetch "https://github.com/user/repo.git@main:tools/script.sh" --out third_party
+npx git-file-fetch "https://github.com/user/repo.git@main:tools/script.sh" --out third_party
 
 # Config file with JSON output
-npx @arkahna-npm/git-file-fetch --config refs.json --out third_party --json --quiet
+npx git-file-fetch --config refs.json --out third_party --json --quiet
 ```
 
 ## Advanced Usage Examples
@@ -88,7 +88,7 @@ npx @arkahna-npm/git-file-fetch --config refs.json --out third_party --json --qu
 ### Multiple Files in One Run
 
 ```bash
-npx @arkahna-npm/git-file-fetch \
+npx git-file-fetch \
   "https://github.com/user/repo.git@v1.2.3:LICENSE" \
   "https://github.com/user/another-repo.git@main:src/templates/readme.md"
 ```
@@ -107,7 +107,7 @@ Create a JSON file with multiple references:
 Then use it:
 
 ```bash
-npx @arkahna-npm/git-file-fetch --config refs.json --out vendor --json
+npx git-file-fetch --config refs.json --out vendor --json
 ```
 
 ## Manifest

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@arkahna-npm/git-file-fetch",
+  "name": "git-file-fetch",
   "version": "0.1.0",
   "description": "Fetch specific files from remote git repos and track them locally.",
   "main": "dist/index.js",
@@ -30,16 +30,16 @@
     "remote",
     "cli"
   ],
-  "author": "Arkahna",
+  "author": "Joshua Boys",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/arkahna/git-file-fetch.git"
+    "url": "git+https://github.com/joshuaboys/git-file-fetch.git"
   },
   "bugs": {
-    "url": "https://github.com/arkahna/git-file-fetch/issues"
+    "url": "https://github.com/joshuaboys/git-file-fetch/issues"
   },
-  "homepage": "https://github.com/arkahna/git-file-fetch#readme",
+  "homepage": "https://github.com/joshuaboys/git-file-fetch#readme",
   "executors": "./plugin/executors.json",
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/plans/FUTURE.md
+++ b/plans/FUTURE.md
@@ -2,6 +2,8 @@
 
 This document outlines the next wave of high-impact features beyond the v1.1 release.
 
+> **Note:** Monorepo workspace support has been moved to v1.1 — see [13-monorepo-workspaces.aps.md](./modules/13-monorepo-workspaces.aps.md)
+
 ## Wave 2: Automation & Integration (v1.2)
 
 ### Watch Mode with Auto-Update
@@ -47,67 +49,6 @@ git-file-fetch watch --interval 60s
 
 ---
 
-### VS Code Extension
-
-**Problem:** Developers must switch to terminal to manage external files.
-
-**Solution:** VS Code extension with visual file management.
-
-**Key Features:**
-- Sidebar showing tracked external files
-- One-click update/verify
-- Inline diff viewing
-- CodeLens showing external file status
-- Command palette integration
-
-**Impact:** Medium-High — Brings functionality to where developers work.
-
----
-
-## Wave 3: Scale & Enterprise (v1.3)
-
-### Monorepo Workspace Support
-
-**Problem:** Large monorepos need per-package external dependencies with shared config.
-
-**Solution:** Workspace-aware configuration with inheritance.
-
-```
-project/
-├── .git-file-fetch.json      # Root config (shared deps)
-├── packages/
-│   ├── pkg-a/
-│   │   └── .git-file-fetch.json  # Package-specific deps
-│   └── pkg-b/
-│       └── .git-file-fetch.json
-```
-
-**Key Features:**
-- Config inheritance (root + local)
-- Workspace-wide update/verify
-- Nx/Turborepo integration
-- Selective package operations
-
-**Impact:** High — Enables enterprise-scale usage.
-
----
-
-### Private Registry Support
-
-**Problem:** Enterprises need to proxy external fetches through internal systems.
-
-**Solution:** Support private git proxies and registries.
-
-**Key Features:**
-- Mirror configuration
-- Registry authentication
-- Audit logging
-- Access control integration
-
-**Impact:** Medium — Unlocks enterprise adoption.
-
----
-
 ### Lock File with Deterministic Builds
 
 **Problem:** Manifest stores refs but not exact content, making builds potentially non-deterministic.
@@ -136,6 +77,78 @@ project/
 - `install` command to restore from lock
 
 **Impact:** High — Guarantees reproducible builds.
+
+---
+
+### VS Code Extension
+
+**Problem:** Developers must switch to terminal to manage external files.
+
+**Solution:** VS Code extension with visual file management.
+
+**Key Features:**
+- Sidebar showing tracked external files
+- One-click update/verify
+- Inline diff viewing
+- CodeLens showing external file status
+- Command palette integration
+
+**Impact:** Medium-High — Brings functionality to where developers work.
+
+---
+
+## Wave 3: Enterprise & Scale (v1.3)
+
+### Private Registry Support
+
+**Problem:** Enterprises need to proxy external fetches through internal systems.
+
+**Solution:** Support private git proxies and registries.
+
+**Key Features:**
+- Mirror configuration
+- Registry authentication
+- Audit logging
+- Access control integration
+
+**Impact:** Medium — Unlocks enterprise adoption.
+
+---
+
+### Dependency Graph & Visualization
+
+**Problem:** Hard to understand relationships between external files and where they come from.
+
+**Solution:** Generate dependency graphs and visualizations.
+
+```bash
+git-file-fetch graph --format mermaid > deps.md
+git-file-fetch graph --format dot | dot -Tpng > deps.png
+```
+
+**Key Features:**
+- Mermaid diagram output
+- Graphviz DOT format
+- HTML interactive visualization
+- Integration with GitHub dependency graph
+
+**Impact:** Medium — Improves visibility and documentation.
+
+---
+
+### Smart Caching Layer
+
+**Problem:** Repeated fetches of same content waste bandwidth and time.
+
+**Solution:** Local cache with content-addressable storage.
+
+**Key Features:**
+- Content-addressable cache (~/.cache/git-file-fetch/)
+- Cache sharing across projects
+- Cache cleanup commands
+- Offline mode using cache
+
+**Impact:** Medium — Significant speed improvement for repeated operations.
 
 ---
 
@@ -209,19 +222,37 @@ git-file-fetch bundle --config deps.json --out deps.tar.gz
 
 ---
 
+### Multi-Provider Support
+
+**Problem:** Not all code lives on GitHub. Teams use GitLab, Bitbucket, Azure DevOps.
+
+**Solution:** First-class support for multiple git providers with provider-specific optimizations.
+
+**Key Features:**
+- Provider auto-detection from URL
+- Provider-specific auth (GitLab tokens, Bitbucket app passwords)
+- API-based fetching where faster than git
+- Rate limit handling per provider
+
+**Impact:** Medium — Expands addressable market.
+
+---
+
 ## Prioritization Matrix
 
-| Feature | Impact | Effort | Priority |
-|---------|--------|--------|----------|
-| Watch Mode | High | Medium | P1 |
-| GitHub Action | High | Low | P1 |
-| Lock File | High | Medium | P1 |
-| Monorepo Support | High | High | P2 |
-| VS Code Extension | Medium-High | High | P2 |
-| Plugin System | Medium | High | P3 |
-| Private Registry | Medium | Medium | P3 |
-| Template/Scaffold | Medium | Medium | P3 |
-| Archive/Bundle | Low-Medium | Low | P4 |
+| Feature | Impact | Effort | Wave | Priority |
+|---------|--------|--------|------|----------|
+| Watch Mode | High | Medium | v1.2 | P1 |
+| GitHub Action | High | Low | v1.2 | P1 |
+| Lock File | High | Medium | v1.2 | P1 |
+| VS Code Extension | Medium-High | High | v1.2 | P2 |
+| Private Registry | Medium | Medium | v1.3 | P2 |
+| Dependency Graph | Medium | Low | v1.3 | P2 |
+| Smart Caching | Medium | Medium | v1.3 | P2 |
+| Plugin System | Medium | High | v2.0 | P3 |
+| Multi-Provider | Medium | Medium | v2.0 | P3 |
+| Template/Scaffold | Medium | Medium | v2.0 | P3 |
+| Archive/Bundle | Low-Medium | Low | v2.0 | P4 |
 
 ---
 

--- a/plans/FUTURE.md
+++ b/plans/FUTURE.md
@@ -1,0 +1,236 @@
+# Future Killer Features (v1.2+)
+
+This document outlines the next wave of high-impact features beyond the v1.1 release.
+
+## Wave 2: Automation & Integration (v1.2)
+
+### Watch Mode with Auto-Update
+
+**Problem:** Developers want external dependencies to stay current automatically during development without manual intervention.
+
+**Solution:** Add `git-file-fetch watch` that monitors source repos and auto-updates files when changes are detected.
+
+```bash
+git-file-fetch watch --interval 60s
+```
+
+**Key Features:**
+- Configurable poll interval
+- Webhook support for instant updates (GitHub webhooks)
+- Desktop notifications on updates
+- Integration with file watchers (nodemon, watchman)
+
+**Impact:** High — Eliminates manual update cycles during active development.
+
+---
+
+### GitHub Actions Native Integration
+
+**Problem:** CI/CD setup requires multiple steps and shell scripting.
+
+**Solution:** Provide a first-party GitHub Action for seamless integration.
+
+```yaml
+- uses: joshuaboys/git-file-fetch-action@v1
+  with:
+    config: deps.json
+    verify: true
+```
+
+**Key Features:**
+- Native action (no npx overhead)
+- Built-in caching of fetched files
+- PR comments on dependency updates
+- Dependency graph integration
+
+**Impact:** High — Reduces CI setup to single step.
+
+---
+
+### VS Code Extension
+
+**Problem:** Developers must switch to terminal to manage external files.
+
+**Solution:** VS Code extension with visual file management.
+
+**Key Features:**
+- Sidebar showing tracked external files
+- One-click update/verify
+- Inline diff viewing
+- CodeLens showing external file status
+- Command palette integration
+
+**Impact:** Medium-High — Brings functionality to where developers work.
+
+---
+
+## Wave 3: Scale & Enterprise (v1.3)
+
+### Monorepo Workspace Support
+
+**Problem:** Large monorepos need per-package external dependencies with shared config.
+
+**Solution:** Workspace-aware configuration with inheritance.
+
+```
+project/
+├── .git-file-fetch.json      # Root config (shared deps)
+├── packages/
+│   ├── pkg-a/
+│   │   └── .git-file-fetch.json  # Package-specific deps
+│   └── pkg-b/
+│       └── .git-file-fetch.json
+```
+
+**Key Features:**
+- Config inheritance (root + local)
+- Workspace-wide update/verify
+- Nx/Turborepo integration
+- Selective package operations
+
+**Impact:** High — Enables enterprise-scale usage.
+
+---
+
+### Private Registry Support
+
+**Problem:** Enterprises need to proxy external fetches through internal systems.
+
+**Solution:** Support private git proxies and registries.
+
+**Key Features:**
+- Mirror configuration
+- Registry authentication
+- Audit logging
+- Access control integration
+
+**Impact:** Medium — Unlocks enterprise adoption.
+
+---
+
+### Lock File with Deterministic Builds
+
+**Problem:** Manifest stores refs but not exact content, making builds potentially non-deterministic.
+
+**Solution:** Add `.git-file-fetch.lock` with exact content hashes and sources.
+
+```json
+{
+  "lockfileVersion": 1,
+  "entries": {
+    "src/utils/logger.ts": {
+      "source": "https://github.com/user/repo.git",
+      "ref": "main",
+      "commit": "abc123...",
+      "contentSha256": "def456...",
+      "fetchedAt": "2025-01-24T10:00:00Z"
+    }
+  }
+}
+```
+
+**Key Features:**
+- Separate lock file from manifest
+- `--frozen` flag for CI (fail if lock mismatch)
+- Lock file auto-update on fetch
+- `install` command to restore from lock
+
+**Impact:** High — Guarantees reproducible builds.
+
+---
+
+## Wave 4: Ecosystem (v2.0)
+
+### Plugin System
+
+**Problem:** Different teams need custom behaviors (special auth, transforms, etc.).
+
+**Solution:** Plugin architecture for extensibility.
+
+```javascript
+// git-file-fetch.config.js
+module.exports = {
+  plugins: [
+    '@company/git-file-fetch-plugin-auth',
+    ['./local-plugin.js', { option: true }]
+  ]
+}
+```
+
+**Key Features:**
+- Lifecycle hooks (pre-fetch, post-fetch, transform)
+- Custom resolvers (private registries, S3, etc.)
+- Auth providers
+- Content transforms (minify, compile, etc.)
+
+**Impact:** Medium — Enables ecosystem growth.
+
+---
+
+### Template/Scaffold Mode
+
+**Problem:** Users want to scaffold new projects from remote templates.
+
+**Solution:** Add `git-file-fetch scaffold` for project templating.
+
+```bash
+git-file-fetch scaffold https://github.com/user/template.git@main \
+  --dest ./new-project \
+  --vars name=myapp,author=me
+```
+
+**Key Features:**
+- Variable substitution in files
+- Interactive prompts for variables
+- Post-scaffold hooks
+- Template registries
+
+**Impact:** Medium — Expands use case beyond dependency management.
+
+---
+
+### Archive/Bundle Mode
+
+**Problem:** Some use cases need a single-file bundle of all external deps.
+
+**Solution:** Add `git-file-fetch bundle` to create distributable archives.
+
+```bash
+git-file-fetch bundle --config deps.json --out deps.tar.gz
+```
+
+**Key Features:**
+- Offline distribution
+- Signature/verification
+- Selective bundling
+- Bundle installation
+
+**Impact:** Low-Medium — Niche but valuable for air-gapped environments.
+
+---
+
+## Prioritization Matrix
+
+| Feature | Impact | Effort | Priority |
+|---------|--------|--------|----------|
+| Watch Mode | High | Medium | P1 |
+| GitHub Action | High | Low | P1 |
+| Lock File | High | Medium | P1 |
+| Monorepo Support | High | High | P2 |
+| VS Code Extension | Medium-High | High | P2 |
+| Plugin System | Medium | High | P3 |
+| Private Registry | Medium | Medium | P3 |
+| Template/Scaffold | Medium | Medium | P3 |
+| Archive/Bundle | Low-Medium | Low | P4 |
+
+---
+
+## Feedback Requested
+
+We'd love community input on these features:
+
+1. Which features would you use immediately?
+2. What's missing from this list?
+3. What integrations matter most to you?
+
+Open an issue or discussion at: https://github.com/joshuaboys/git-file-fetch/discussions

--- a/plans/index.aps.md
+++ b/plans/index.aps.md
@@ -20,6 +20,7 @@ Enhance git-file-fetch from a basic file fetching CLI to a comprehensive externa
 - [ ] Concurrent fetching reduces wait time for large configs
 - [ ] Progress indicators show network operation status
 - [ ] Shell completions available for bash/zsh/fish
+- [ ] Monorepo workspaces supported with config inheritance
 
 ## Constraints
 
@@ -39,7 +40,8 @@ graph TB
     CMD --> LIST[list]
     CMD --> INIT[init]
 
-    FETCH --> GLOB[Glob Resolver]
+    FETCH --> WORKSPACE[Workspace Resolver]
+    WORKSPACE --> GLOB[Glob Resolver]
     FETCH --> CONCURRENT[Concurrent Fetcher]
     UPDATE --> MANIFEST[Manifest Reader]
     VERIFY --> MANIFEST
@@ -76,6 +78,12 @@ graph TB
 - **Includes:** progress-indicators, shell-completion, init-command, error-hints
 - **Gate:** Polished CLI experience
 
+### M4: Monorepo & Scale
+
+- **Target:** Sprint 4
+- **Includes:** monorepo-workspaces
+- **Gate:** Workspace-aware operations with config inheritance
+
 ## Modules
 
 | Module | Scope | Owner | Status | Priority | Tags | Dependencies |
@@ -92,6 +100,7 @@ graph TB
 | [10-list-command](./modules/10-list-command.aps.md) | WORKFLOW | — | Draft | medium | cli, manifest | npm-publish |
 | [11-init-command](./modules/11-init-command.aps.md) | UX | — | Draft | medium | cli | npm-publish |
 | [12-error-hints](./modules/12-error-hints.aps.md) | UX | — | Draft | medium | cli | npm-publish |
+| [13-monorepo-workspaces](./modules/13-monorepo-workspaces.aps.md) | SCALE | — | Draft | high | workspace, config | npm-publish |
 
 ## Risks & Mitigations
 
@@ -120,4 +129,4 @@ See [FUTURE.md](./FUTURE.md) for next-wave killer features:
 - Watch mode with auto-update
 - GitHub Actions native integration
 - VS Code extension
-- Monorepo support with workspace configs
+- Lock file for deterministic builds

--- a/plans/index.aps.md
+++ b/plans/index.aps.md
@@ -1,0 +1,123 @@
+<!-- APS: Anvil Plan Specification -->
+<!-- This document is non-executable. -->
+
+# git-file-fetch v1.1 Feature Release
+
+## Overview
+
+Enhance git-file-fetch from a basic file fetching CLI to a comprehensive external dependency management tool. This release focuses on workflow automation (update/verify commands), developer experience improvements, and npm publishing.
+
+## Problem & Success Criteria
+
+**Problem:** git-file-fetch can fetch files but lacks essential workflow features for maintaining external dependencies over time. Users cannot easily update fetched files, verify they haven't drifted, or fetch multiple files using patterns.
+
+**Success Criteria:**
+
+- [ ] Package published to npm registry with provenance
+- [ ] Users can update all manifest entries with single command
+- [ ] Users can verify local files match remote sources
+- [ ] Users can fetch multiple files using glob patterns
+- [ ] Concurrent fetching reduces wait time for large configs
+- [ ] Progress indicators show network operation status
+- [ ] Shell completions available for bash/zsh/fish
+
+## Constraints
+
+- Must maintain backward compatibility with existing CLI and manifest format
+- Must not add runtime dependencies (keep zero-dependency design)
+- Must pass CI on all platforms (Linux, macOS, Windows)
+- Must support Node.js 22, 23, 24
+
+## System Map
+
+```mermaid
+graph TB
+    CLI[CLI Entry] --> CMD{Command}
+    CMD --> FETCH[fetch]
+    CMD --> UPDATE[update]
+    CMD --> VERIFY[verify]
+    CMD --> LIST[list]
+    CMD --> INIT[init]
+
+    FETCH --> GLOB[Glob Resolver]
+    FETCH --> CONCURRENT[Concurrent Fetcher]
+    UPDATE --> MANIFEST[Manifest Reader]
+    VERIFY --> MANIFEST
+    VERIFY --> INTEGRITY[Integrity Checker]
+
+    CONCURRENT --> PROGRESS[Progress Reporter]
+    GLOB --> GIT[Git Operations]
+    CONCURRENT --> GIT
+```
+
+## Milestones
+
+### M0: npm Publishing
+
+- **Target:** Immediate
+- **Includes:** npm-publish module
+- **Gate:** Package accessible via `npx git-file-fetch`
+
+### M1: Workflow Commands
+
+- **Target:** Sprint 1
+- **Includes:** update-command, verify-command, list-command
+- **Gate:** Users can manage dependencies through manifest
+
+### M2: Power Features
+
+- **Target:** Sprint 2
+- **Includes:** glob-support, concurrent-fetch, integrity-check
+- **Gate:** Performance and batch operations ready
+
+### M3: Developer Experience
+
+- **Target:** Sprint 3
+- **Includes:** progress-indicators, shell-completion, init-command, error-hints
+- **Gate:** Polished CLI experience
+
+## Modules
+
+| Module | Scope | Owner | Status | Priority | Tags | Dependencies |
+|--------|-------|-------|--------|----------|------|--------------|
+| [01-npm-publish](./modules/01-npm-publish.aps.md) | RELEASE | — | Ready | critical | npm, ci | — |
+| [02-update-command](./modules/02-update-command.aps.md) | WORKFLOW | — | Draft | high | cli, manifest | npm-publish |
+| [03-verify-command](./modules/03-verify-command.aps.md) | WORKFLOW | — | Draft | high | cli, manifest | npm-publish |
+| [04-glob-support](./modules/04-glob-support.aps.md) | FETCH | — | Draft | high | cli, git | npm-publish |
+| [05-diff-preview](./modules/05-diff-preview.aps.md) | UX | — | Draft | high | cli | npm-publish |
+| [06-integrity-check](./modules/06-integrity-check.aps.md) | SECURITY | — | Draft | high | manifest, verify | verify-command |
+| [07-concurrent-fetch](./modules/07-concurrent-fetch.aps.md) | PERF | — | Draft | high | fetch | npm-publish |
+| [08-progress-indicators](./modules/08-progress-indicators.aps.md) | UX | — | Draft | medium | cli | npm-publish |
+| [09-shell-completion](./modules/09-shell-completion.aps.md) | UX | — | Draft | medium | cli | npm-publish |
+| [10-list-command](./modules/10-list-command.aps.md) | WORKFLOW | — | Draft | medium | cli, manifest | npm-publish |
+| [11-init-command](./modules/11-init-command.aps.md) | UX | — | Draft | medium | cli | npm-publish |
+| [12-error-hints](./modules/12-error-hints.aps.md) | UX | — | Draft | medium | cli | npm-publish |
+
+## Risks & Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| npm name `git-file-fetch` taken | high | low | Check availability before publishing |
+| Glob patterns expose security holes | high | medium | Strict path validation, no `..` in patterns |
+| Concurrent fetches overwhelm git | medium | medium | Configurable concurrency limit, default 4 |
+| Breaking manifest format | high | low | Version field, migration path |
+
+## Decisions
+
+- **D-001:** Keep zero runtime dependencies — bundle any utilities needed
+- **D-002:** Use SHA-256 for content integrity — matches existing remote naming
+- **D-003:** Glob expansion happens client-side via git ls-tree — no new git operations
+
+## Open Questions
+
+- [ ] Should `update` command support `--ref` to update all entries to a new ref?
+- [ ] Should `verify` return non-zero if any file differs (for CI)?
+- [ ] What's the concurrency default? (4? 8? based on CPU?)
+
+## Future Waves (v1.2+)
+
+See [FUTURE.md](./FUTURE.md) for next-wave killer features:
+- Watch mode with auto-update
+- GitHub Actions native integration
+- VS Code extension
+- Monorepo support with workspace configs

--- a/plans/modules/01-npm-publish.aps.md
+++ b/plans/modules/01-npm-publish.aps.md
@@ -1,0 +1,119 @@
+<!-- APS: Anvil Plan Specification -->
+<!-- Executable only if work items exist and status is Ready. -->
+
+# npm Publishing Module
+
+| Scope | Owner | Priority | Status |
+|-------|-------|----------|--------|
+| RELEASE | — | critical | Ready |
+
+## Purpose
+
+Publish git-file-fetch to the npm registry with provenance, making it installable via `npm install git-file-fetch` and runnable via `npx git-file-fetch`.
+
+## In Scope
+
+- Verify package.json metadata is complete
+- Set up NPM_TOKEN in GitHub Secrets
+- Tag release and trigger publish workflow
+- Verify package is accessible post-publish
+- Update README badges and documentation
+
+## Out of Scope
+
+- Scoped package publishing (@org/package)
+- Publishing to private registries
+- Automated changelog generation
+
+## Interfaces
+
+**Depends on:**
+
+- GitHub Actions secrets — `NPM_TOKEN`
+- npm registry — public access
+
+**Exposes:**
+
+- `npx git-file-fetch` — global CLI access
+- `npm install git-file-fetch` — local installation
+
+## Boundary Rules
+
+- RELEASE must not modify source code functionality
+- RELEASE must not change existing CLI behavior
+
+## Acceptance Criteria
+
+- [ ] `npm view git-file-fetch` returns package metadata
+- [ ] `npx git-file-fetch --version` prints version number
+- [ ] `npx git-file-fetch --help` shows usage
+- [ ] Package has provenance attestation on npmjs.com
+- [ ] README badges show correct npm version
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Package name already taken | Verify availability: `npm view git-file-fetch` returns 404 |
+| Token permissions insufficient | Use `id-token: write` for provenance |
+| Publish workflow fails | Test with `npm pack` and local install first |
+
+## Work Items
+
+### NPM-001: Verify npm package name availability
+
+- **Intent:** Confirm `git-file-fetch` is available on npm registry
+- **Expected Outcome:** `npm view git-file-fetch` returns E404
+- **Scope:** Registry check only
+- **Non-scope:** Alternative name selection
+- **Files:** None
+- **Dependencies:** None
+- **Validation:** `npm view git-file-fetch 2>&1 | grep -q "E404"`
+- **Confidence:** high
+- **Risks:** Name could be claimed between check and publish
+
+### NPM-002: Configure NPM_TOKEN in GitHub Secrets
+
+- **Intent:** Enable automated npm publishing from GitHub Actions
+- **Expected Outcome:** Secret `NPM_TOKEN` available to publish workflow
+- **Scope:** GitHub repository settings
+- **Non-scope:** Token generation (done manually on npmjs.com)
+- **Files:** None (manual configuration)
+- **Dependencies:** NPM-001
+- **Validation:** Push tag and verify workflow accesses secret
+- **Confidence:** high
+- **Risks:** Token scope must include publish
+
+### NPM-003: Create and push release tag
+
+- **Intent:** Trigger the publish workflow via git tag
+- **Expected Outcome:** Tag `v0.1.0` pushed, workflow runs successfully
+- **Scope:** Git tag creation and push
+- **Non-scope:** Version bump (already at 0.1.0)
+- **Files:** None
+- **Dependencies:** NPM-002
+- **Validation:** `git tag -l v0.1.0` shows tag, GitHub Actions shows green
+- **Confidence:** high
+- **Risks:** Workflow may fail on first attempt
+
+### NPM-004: Verify published package
+
+- **Intent:** Confirm package is accessible and functional
+- **Expected Outcome:** Package installable and runnable
+- **Scope:** Post-publish verification
+- **Non-scope:** Performance testing
+- **Files:** None
+- **Dependencies:** NPM-003
+- **Validation:** `npx git-file-fetch@0.1.0 --version` prints `0.1.0`
+- **Confidence:** high
+- **Risks:** npm propagation delay (usually <5 min)
+
+## Decisions
+
+- **D-001:** Publish as unscoped package — simpler, more discoverable
+- **D-002:** Use GitHub Actions OIDC for provenance — no long-lived tokens
+
+## Notes
+
+- Existing `.github/workflows/publish.yml` handles the publish process
+- Package already configured with `"access": "public"` and `"provenance": true`

--- a/plans/modules/02-update-command.aps.md
+++ b/plans/modules/02-update-command.aps.md
@@ -1,0 +1,120 @@
+<!-- APS: Anvil Plan Specification -->
+<!-- Executable only if work items exist and status is Ready. -->
+
+# Update Command Module
+
+| Scope | Owner | Priority | Status |
+|-------|-------|----------|--------|
+| WORKFLOW | — | high | Draft |
+
+## Purpose
+
+Add an `update` command that re-fetches all files tracked in the manifest, updating them to the latest commit on their recorded refs. Essential for keeping external dependencies current.
+
+## In Scope
+
+- Read manifest entries and re-fetch each file
+- Update manifest with new commit SHAs
+- Support `--dry-run` to preview updates
+- Support filtering by repo or path pattern
+- Report which files changed vs unchanged
+
+## Out of Scope
+
+- Changing refs (e.g., updating from `v1.0` to `v2.0`)
+- Interactive selection of files to update
+- Automatic commit of changes
+
+## Interfaces
+
+**Depends on:**
+
+- Manifest file — `.git-remote-files.json`
+- Existing fetch logic — `fetchFileMinimal()`
+
+**Exposes:**
+
+- `git-file-fetch update` — re-fetch all manifest entries
+- `git-file-fetch update --filter <pattern>` — selective update
+
+## Boundary Rules
+
+- UPDATE must reuse existing fetch/write logic
+- UPDATE must not modify refs in manifest (only commit SHAs)
+
+## Acceptance Criteria
+
+- [ ] `git-file-fetch update` re-fetches all manifest entries
+- [ ] `git-file-fetch update --dry-run` shows what would change
+- [ ] Changed files are reported distinctly from unchanged
+- [ ] Manifest commit SHAs are updated after successful fetch
+- [ ] Exit code 0 if all updates succeed, 1 if any fail
+- [ ] `--json` output includes update status per file
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Large manifests slow to update | Add concurrency (see concurrent-fetch module) |
+| Network failures mid-update | Atomic manifest write after all fetches complete |
+| Ref no longer exists | Clear error message, skip entry, continue others |
+
+## Work Items
+
+### UPDATE-001: Parse `update` subcommand
+
+- **Intent:** Recognize `update` as a command and route to handler
+- **Expected Outcome:** `git-file-fetch update` invokes update logic
+- **Scope:** CLI argument parsing in `main()`
+- **Non-scope:** Update implementation
+- **Files:** `src/index.ts`
+- **Dependencies:** None
+- **Validation:** `node dist/index.js update --help` shows update-specific help
+- **Confidence:** high
+- **Risks:** None
+
+### UPDATE-002: Implement manifest re-fetch logic
+
+- **Intent:** Iterate manifest entries and re-fetch each file
+- **Expected Outcome:** All manifest files updated to latest commits
+- **Scope:** New `runUpdate()` function
+- **Non-scope:** Concurrency, filtering
+- **Files:** `src/index.ts`
+- **Dependencies:** UPDATE-001
+- **Validation:** `git-file-fetch update --dry-run` lists all manifest entries
+- **Confidence:** high
+- **Risks:** None
+
+### UPDATE-003: Add change detection and reporting
+
+- **Intent:** Report which files actually changed vs unchanged
+- **Expected Outcome:** Output distinguishes changed/unchanged files
+- **Scope:** Compare old vs new commit SHA, file content hash
+- **Non-scope:** Diff display
+- **Files:** `src/index.ts`
+- **Dependencies:** UPDATE-002
+- **Validation:** Re-run update twice, second run shows "unchanged"
+- **Confidence:** medium
+- **Risks:** Content comparison adds overhead
+
+### UPDATE-004: Add `--filter` option
+
+- **Intent:** Allow selective updates by repo URL or path pattern
+- **Expected Outcome:** Only matching entries are updated
+- **Scope:** Filter parsing and manifest filtering
+- **Non-scope:** Complex glob patterns (simple substring match)
+- **Files:** `src/index.ts`
+- **Dependencies:** UPDATE-002
+- **Validation:** `git-file-fetch update --filter github.com/user` updates only matching
+- **Confidence:** high
+- **Risks:** None
+
+## Decisions
+
+- **D-001:** Update preserves original ref — only commit SHA changes
+- **D-002:** Atomic manifest update — write only after all fetches succeed
+
+## Notes
+
+- Consider adding `--ref <newref>` in future to bulk-update refs
+- Should integrate with concurrent-fetch module when available

--- a/plans/modules/03-verify-command.aps.md
+++ b/plans/modules/03-verify-command.aps.md
@@ -1,0 +1,122 @@
+<!-- APS: Anvil Plan Specification -->
+<!-- Executable only if work items exist and status is Ready. -->
+
+# Verify Command Module
+
+| Scope | Owner | Priority | Status |
+|-------|-------|----------|--------|
+| WORKFLOW | — | high | Draft |
+
+## Purpose
+
+Add a `verify` command that compares local files against their recorded sources in the manifest. Essential for CI pipelines to detect drift without modifying files.
+
+## In Scope
+
+- Compare local file content against remote at recorded commit SHA
+- Report matches, mismatches, and missing files
+- Support `--changed-only` to show only differences
+- Exit with non-zero code if any mismatches (CI-friendly)
+- JSON output for automation
+
+## Out of Scope
+
+- Showing actual diffs (see diff-preview module)
+- Auto-fixing mismatches
+- Verifying against latest commit (that's update --dry-run)
+
+## Interfaces
+
+**Depends on:**
+
+- Manifest file — `.git-remote-files.json`
+- Local file system — fetched files
+- Git operations — fetch remote content at specific SHA
+
+**Exposes:**
+
+- `git-file-fetch verify` — check all manifest entries
+- `git-file-fetch verify --changed-only` — show only mismatches
+
+## Boundary Rules
+
+- VERIFY must not write any files
+- VERIFY must not modify manifest
+- VERIFY must use recorded commit SHA, not latest
+
+## Acceptance Criteria
+
+- [ ] `git-file-fetch verify` compares all manifest entries
+- [ ] Exit code 0 if all match, 1 if any mismatch
+- [ ] Output clearly shows: match, mismatch, missing local, missing remote
+- [ ] `--changed-only` suppresses matching files from output
+- [ ] `--json` returns structured verification results
+- [ ] Works in CI without interactive prompts
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Fetching remote content slow | Cache fetched content within single run |
+| Binary files comparison | Use byte-level comparison, not text |
+| Large files memory pressure | Stream comparison, don't load entire file |
+
+## Work Items
+
+### VERIFY-001: Parse `verify` subcommand
+
+- **Intent:** Recognize `verify` command and route to handler
+- **Expected Outcome:** `git-file-fetch verify` invokes verify logic
+- **Scope:** CLI argument parsing
+- **Non-scope:** Verification implementation
+- **Files:** `src/index.ts`
+- **Dependencies:** None
+- **Validation:** `node dist/index.js verify --help` shows verify help
+- **Confidence:** high
+- **Risks:** None
+
+### VERIFY-002: Implement remote content fetch at SHA
+
+- **Intent:** Fetch file content at specific commit SHA (not ref)
+- **Expected Outcome:** Can retrieve exact content as recorded in manifest
+- **Scope:** Git show with full SHA
+- **Non-scope:** Caching (future optimization)
+- **Files:** `src/index.ts`
+- **Dependencies:** VERIFY-001
+- **Validation:** Fetch file at old SHA returns old content
+- **Confidence:** high
+- **Risks:** SHA may no longer exist (repo force-pushed)
+
+### VERIFY-003: Implement comparison and reporting
+
+- **Intent:** Compare local vs remote, report status
+- **Expected Outcome:** Clear output showing verification results
+- **Scope:** Byte comparison, status reporting
+- **Non-scope:** Diff generation
+- **Files:** `src/index.ts`
+- **Dependencies:** VERIFY-002
+- **Validation:** Modify local file, verify reports mismatch
+- **Confidence:** high
+- **Risks:** None
+
+### VERIFY-004: Add `--changed-only` flag
+
+- **Intent:** Filter output to show only mismatches
+- **Expected Outcome:** Matching files suppressed from output
+- **Scope:** Output filtering
+- **Non-scope:** None
+- **Files:** `src/index.ts`
+- **Dependencies:** VERIFY-003
+- **Validation:** With all files matching, `--changed-only` produces empty output
+- **Confidence:** high
+- **Risks:** None
+
+## Decisions
+
+- **D-001:** Verify uses recorded SHA, not latest — ensures reproducibility
+- **D-002:** Non-zero exit on mismatch — enables `verify && deploy` patterns
+
+## Notes
+
+- Natural companion to `update` command
+- Integrity module will add checksum verification on top of this

--- a/plans/modules/04-glob-support.aps.md
+++ b/plans/modules/04-glob-support.aps.md
@@ -1,0 +1,123 @@
+<!-- APS: Anvil Plan Specification -->
+<!-- Executable only if work items exist and status is Ready. -->
+
+# Glob Pattern Support Module
+
+| Scope | Owner | Priority | Status |
+|-------|-------|----------|--------|
+| FETCH | — | high | Draft |
+
+## Purpose
+
+Enable fetching multiple files using glob patterns like `src/**/*.ts`. Dramatically reduces configuration overhead when importing multiple files from external repos.
+
+## In Scope
+
+- Parse glob patterns in file path position
+- Expand patterns to file list using `git ls-tree`
+- Fetch all matched files
+- Add all matches to manifest individually
+- Support common patterns: `*`, `**`, `?`, `[abc]`
+
+## Out of Scope
+
+- Negative patterns (exclusions)
+- Pattern matching across multiple repos
+- Recursive directory fetch without pattern
+
+## Interfaces
+
+**Depends on:**
+
+- Git ls-tree — enumerate files at ref
+- Existing fetch logic — fetch individual files
+- Manifest — store individual file entries
+
+**Exposes:**
+
+- Glob pattern in path position: `repo.git@ref:src/**/*.ts`
+- `--dry-run` shows expanded file list
+
+## Boundary Rules
+
+- GLOB must expand patterns before fetching
+- GLOB must create individual manifest entries (not pattern)
+- GLOB must validate expanded paths don't escape boundaries
+
+## Acceptance Criteria
+
+- [ ] `repo@ref:src/*.ts` fetches all .ts files in src/
+- [ ] `repo@ref:src/**/*.ts` fetches .ts files recursively
+- [ ] `--dry-run` shows list of files that would be fetched
+- [ ] Each matched file gets individual manifest entry
+- [ ] Invalid patterns produce clear error messages
+- [ ] Path traversal attempts in patterns are rejected
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Pattern matches thousands of files | Add `--limit N` flag, warn above threshold |
+| Security: pattern escapes directory | Validate all expanded paths, reject `..` |
+| Performance: ls-tree on huge repos | Use sparse checkout patterns if available |
+
+## Work Items
+
+### GLOB-001: Detect glob patterns in path
+
+- **Intent:** Recognize when path contains glob characters
+- **Expected Outcome:** `hasGlobPattern()` returns true for `*.ts`
+- **Scope:** Pattern detection logic
+- **Non-scope:** Pattern expansion
+- **Files:** `src/index.ts`
+- **Dependencies:** None
+- **Validation:** `hasGlobPattern('src/*.ts')` returns true
+- **Confidence:** high
+- **Risks:** None
+
+### GLOB-002: Implement git ls-tree file enumeration
+
+- **Intent:** List files matching pattern at specific ref
+- **Expected Outcome:** Array of file paths matching pattern
+- **Scope:** Git ls-tree execution and parsing
+- **Non-scope:** Pattern matching (use git's pathspec)
+- **Files:** `src/index.ts`
+- **Dependencies:** GLOB-001
+- **Validation:** ls-tree with `*.md` returns markdown files
+- **Confidence:** medium
+- **Risks:** Git pathspec syntax differs from shell glob
+
+### GLOB-003: Expand patterns and fetch files
+
+- **Intent:** Convert pattern to file list and fetch each
+- **Expected Outcome:** All matched files fetched and in manifest
+- **Scope:** Integration of ls-tree with fetch loop
+- **Non-scope:** Concurrency (see concurrent-fetch)
+- **Files:** `src/index.ts`
+- **Dependencies:** GLOB-002
+- **Validation:** `repo@ref:docs/*.md --dry-run` lists all docs
+- **Confidence:** high
+- **Risks:** Large expansion could be slow
+
+### GLOB-004: Add safety limits and warnings
+
+- **Intent:** Prevent accidental huge fetches
+- **Expected Outcome:** Warning when pattern matches >100 files, limit flag
+- **Scope:** Threshold check and `--limit` flag
+- **Non-scope:** Interactive confirmation
+- **Files:** `src/index.ts`
+- **Dependencies:** GLOB-003
+- **Validation:** Pattern matching 1000 files warns user
+- **Confidence:** high
+- **Risks:** None
+
+## Decisions
+
+- **D-001:** Use git pathspec for matching — consistent with git behavior
+- **D-002:** Store expanded files individually — enables per-file update/verify
+- **D-003:** Default limit 100 files — require `--limit` or `--no-limit` for more
+
+## Notes
+
+- Consider supporting `.gitignore`-style patterns in future
+- Pattern expansion should respect `--out` directory structure

--- a/plans/modules/05-diff-preview.aps.md
+++ b/plans/modules/05-diff-preview.aps.md
@@ -1,0 +1,90 @@
+<!-- APS: Anvil Plan Specification -->
+<!-- Executable only if work items exist and status is Ready. -->
+
+# Diff Preview Module
+
+| Scope | Owner | Priority | Status |
+|-------|-------|----------|--------|
+| UX | — | high | Draft |
+
+## Purpose
+
+Add `--preview` flag that shows a diff of what would change before overwriting files. Enables informed decisions before modifying local files.
+
+## In Scope
+
+- Generate unified diff between local and remote content
+- Show diff in terminal with color highlighting
+- Support `--preview` on fetch and update commands
+- Configurable context lines
+
+## Out of Scope
+
+- Interactive patching (accept/reject hunks)
+- Side-by-side diff view
+- Diff for binary files (show "binary differs")
+
+## Interfaces
+
+**Depends on:**
+
+- Local file content
+- Remote file content (fetched but not written)
+
+**Exposes:**
+
+- `git-file-fetch --preview` — show diff before writing
+- `git-file-fetch update --preview` — show all update diffs
+
+## Acceptance Criteria
+
+- [ ] `--preview` shows unified diff for changed files
+- [ ] Diff uses color when terminal supports it
+- [ ] New files show entire content as additions
+- [ ] Deleted content shows as removals
+- [ ] `--preview` prevents file writes (implicit dry-run)
+- [ ] Binary files show "Binary files differ" message
+
+## Work Items
+
+### DIFF-001: Implement unified diff generation
+
+- **Intent:** Generate diff between two strings
+- **Expected Outcome:** Unified diff format output
+- **Scope:** Diff algorithm (use simple line-based)
+- **Files:** `src/index.ts`
+- **Dependencies:** None
+- **Validation:** Diff of "a\nb" vs "a\nc" shows -b +c
+- **Confidence:** medium
+- **Risks:** Edge cases in diff algorithm
+
+### DIFF-002: Add terminal color support
+
+- **Intent:** Colorize diff output (red/green)
+- **Expected Outcome:** Additions green, deletions red
+- **Scope:** ANSI color codes, TTY detection
+- **Files:** `src/index.ts`
+- **Dependencies:** DIFF-001
+- **Validation:** Diff shows colors in terminal
+- **Confidence:** high
+- **Risks:** Windows terminal compatibility
+
+### DIFF-003: Integrate `--preview` flag
+
+- **Intent:** Add flag to show diff before write
+- **Expected Outcome:** `--preview` shows diff, skips write
+- **Scope:** CLI flag, integration with fetch flow
+- **Files:** `src/index.ts`
+- **Dependencies:** DIFF-002
+- **Validation:** `--preview` shows diff, file unchanged
+- **Confidence:** high
+- **Risks:** None
+
+## Decisions
+
+- **D-001:** Use simple line-based diff — no external dependencies
+- **D-002:** `--preview` implies `--dry-run` — never write with preview
+
+## Notes
+
+- Could add `--preview=full` vs `--preview=stat` modes later

--- a/plans/modules/06-integrity-check.aps.md
+++ b/plans/modules/06-integrity-check.aps.md
@@ -1,0 +1,101 @@
+<!-- APS: Anvil Plan Specification -->
+<!-- Executable only if work items exist and status is Ready. -->
+
+# Content Integrity Module
+
+| Scope | Owner | Priority | Status |
+|-------|-------|----------|--------|
+| SECURITY | — | high | Draft |
+
+## Purpose
+
+Add SHA-256 content checksums to manifest entries for tamper detection. Enables offline verification without network access and provides defense against supply chain attacks.
+
+## In Scope
+
+- Calculate SHA-256 hash of fetched file content
+- Store hash in manifest alongside other metadata
+- Verify local file matches recorded hash
+- Support `verify --offline` using only checksums
+
+## Out of Scope
+
+- Signing manifests (GPG, etc.)
+- Hash algorithm selection (always SHA-256)
+- Verifying remote content hash
+
+## Interfaces
+
+**Depends on:**
+
+- Node.js crypto — SHA-256 hashing
+- Manifest format — new `contentSha256` field
+
+**Exposes:**
+
+- `contentSha256` field in manifest entries
+- `verify --offline` — verify using checksums only
+
+## Acceptance Criteria
+
+- [ ] New fetches include `contentSha256` in manifest
+- [ ] Existing manifests work without hash (backward compatible)
+- [ ] `verify` checks hash when present
+- [ ] `verify --offline` works without network
+- [ ] Hash mismatch produces clear error with expected vs actual
+- [ ] `--json` output includes hash verification status
+
+## Work Items
+
+### INTEGRITY-001: Add hash calculation on fetch
+
+- **Intent:** Calculate SHA-256 of content during fetch
+- **Expected Outcome:** Hash computed for every fetched file
+- **Scope:** Crypto hash computation
+- **Files:** `src/index.ts`
+- **Dependencies:** None
+- **Validation:** Hash matches `sha256sum` of fetched file
+- **Confidence:** high
+- **Risks:** None
+
+### INTEGRITY-002: Store hash in manifest
+
+- **Intent:** Persist hash in manifest entry
+- **Expected Outcome:** `contentSha256` field in manifest JSON
+- **Scope:** Manifest schema update
+- **Files:** `src/index.ts`
+- **Dependencies:** INTEGRITY-001
+- **Validation:** Manifest contains 64-char hex hash
+- **Confidence:** high
+- **Risks:** None
+
+### INTEGRITY-003: Verify hash on verify command
+
+- **Intent:** Check local file against recorded hash
+- **Expected Outcome:** Hash verification in verify output
+- **Scope:** Hash comparison in verify flow
+- **Files:** `src/index.ts`
+- **Dependencies:** INTEGRITY-002, VERIFY-003
+- **Validation:** Modified file fails hash check
+- **Confidence:** high
+- **Risks:** None
+
+### INTEGRITY-004: Add `--offline` flag to verify
+
+- **Intent:** Enable verification without network
+- **Expected Outcome:** `verify --offline` uses only local hash
+- **Scope:** Skip remote fetch when offline flag set
+- **Files:** `src/index.ts`
+- **Dependencies:** INTEGRITY-003
+- **Validation:** `--offline` works with network disabled
+- **Confidence:** high
+- **Risks:** None
+
+## Decisions
+
+- **D-001:** Use SHA-256 — widely supported, secure, matches git internals
+- **D-002:** Hash is optional in manifest — backward compatible with existing
+
+## Notes
+
+- Consider adding `--verify-integrity` flag for fetch to re-verify after write

--- a/plans/modules/07-concurrent-fetch.aps.md
+++ b/plans/modules/07-concurrent-fetch.aps.md
@@ -1,0 +1,102 @@
+<!-- APS: Anvil Plan Specification -->
+<!-- Executable only if work items exist and status is Ready. -->
+
+# Concurrent Fetch Module
+
+| Scope | Owner | Priority | Status |
+|-------|-------|----------|--------|
+| PERF | — | high | Draft |
+
+## Purpose
+
+Enable parallel file fetching to dramatically reduce total time when processing multiple files. A config with 20 files should complete in ~4x time of one file, not 20x.
+
+## In Scope
+
+- Parallel git operations with configurable concurrency
+- Progress tracking across concurrent operations
+- Error handling without failing entire batch
+- `--concurrency N` flag
+
+## Out of Scope
+
+- Connection pooling
+- Rate limiting per host
+- Streaming/partial downloads
+
+## Interfaces
+
+**Depends on:**
+
+- Existing fetch logic — `fetchFileMinimal()`
+- Promise-based execution
+
+**Exposes:**
+
+- `--concurrency N` — limit parallel operations (default: 4)
+- Parallel execution of fetch/update/verify
+
+## Acceptance Criteria
+
+- [ ] Multiple files fetch in parallel
+- [ ] Default concurrency is 4
+- [ ] `--concurrency 1` forces sequential execution
+- [ ] Errors in one file don't block others
+- [ ] All results collected and reported together
+- [ ] Total time significantly less than sequential
+
+## Work Items
+
+### CONCURRENT-001: Refactor fetch to async/Promise-based
+
+- **Intent:** Enable concurrent execution of fetch operations
+- **Expected Outcome:** Fetch returns Promise, can run in parallel
+- **Scope:** Convert sync operations to async
+- **Files:** `src/index.ts`
+- **Dependencies:** None
+- **Validation:** Single fetch still works correctly
+- **Confidence:** medium
+- **Risks:** Breaking sync-dependent code
+
+### CONCURRENT-002: Implement concurrent execution pool
+
+- **Intent:** Run multiple fetches with concurrency limit
+- **Expected Outcome:** N operations run simultaneously
+- **Scope:** Promise pool implementation
+- **Files:** `src/index.ts`
+- **Dependencies:** CONCURRENT-001
+- **Validation:** 4 files with concurrency 2 shows 2 at a time
+- **Confidence:** medium
+- **Risks:** Resource exhaustion if limit too high
+
+### CONCURRENT-003: Add `--concurrency` flag
+
+- **Intent:** User-configurable parallelism
+- **Expected Outcome:** Flag controls concurrent operation count
+- **Scope:** CLI parsing, pool configuration
+- **Files:** `src/index.ts`
+- **Dependencies:** CONCURRENT-002
+- **Validation:** `--concurrency 8` runs 8 parallel
+- **Confidence:** high
+- **Risks:** None
+
+### CONCURRENT-004: Aggregate results and errors
+
+- **Intent:** Collect all results regardless of individual failures
+- **Expected Outcome:** Complete report even if some files fail
+- **Scope:** Result aggregation, partial success handling
+- **Files:** `src/index.ts`
+- **Dependencies:** CONCURRENT-002
+- **Validation:** 1 of 4 fails, other 3 succeed and report
+- **Confidence:** high
+- **Risks:** None
+
+## Decisions
+
+- **D-001:** Default concurrency 4 — balances speed vs resource usage
+- **D-002:** Fail-open model — failures don't stop other fetches
+
+## Notes
+
+- Consider `FETCH_GIT_FILE_CONCURRENCY` env var
+- Progress module should show concurrent operation status

--- a/plans/modules/08-progress-indicators.aps.md
+++ b/plans/modules/08-progress-indicators.aps.md
@@ -1,0 +1,91 @@
+<!-- APS: Anvil Plan Specification -->
+<!-- Executable only if work items exist and status is Ready. -->
+
+# Progress Indicators Module
+
+| Scope | Owner | Priority | Status |
+|-------|-------|----------|--------|
+| UX | — | medium | Draft |
+
+## Purpose
+
+Add visual progress indicators for network operations. Users should see activity during long-running operations, not a blank terminal.
+
+## In Scope
+
+- Spinner during git operations
+- Progress bar for multiple file operations
+- File count progress (3/10 files)
+- Disable in non-TTY or with `--quiet`
+
+## Out of Scope
+
+- Download speed/ETA estimation
+- Detailed transfer progress
+- GUI progress bars
+
+## Interfaces
+
+**Depends on:**
+
+- TTY detection — `process.stdout.isTTY`
+- Operation lifecycle hooks
+
+**Exposes:**
+
+- Visual spinner during single operations
+- Progress bar during multi-file operations
+- `--no-progress` flag to disable
+
+## Acceptance Criteria
+
+- [ ] Spinner shows during git fetch
+- [ ] Progress shows "Fetching file 3/10..."
+- [ ] No progress output with `--quiet` or `--json`
+- [ ] No progress output when piped (non-TTY)
+- [ ] Progress clears cleanly on completion
+- [ ] Works on Windows, macOS, Linux terminals
+
+## Work Items
+
+### PROGRESS-001: Implement TTY-aware spinner
+
+- **Intent:** Show activity during single long operations
+- **Expected Outcome:** Animated spinner in TTY, nothing in pipe
+- **Scope:** Spinner animation, TTY detection
+- **Files:** `src/index.ts`
+- **Dependencies:** None
+- **Validation:** Spinner visible in terminal, absent in `| cat`
+- **Confidence:** high
+- **Risks:** Windows terminal compatibility
+
+### PROGRESS-002: Implement file count progress
+
+- **Intent:** Show "3/10 files" during batch operations
+- **Expected Outcome:** Counter updates as files complete
+- **Scope:** Counter display, line clearing
+- **Files:** `src/index.ts`
+- **Dependencies:** PROGRESS-001
+- **Validation:** Multi-file fetch shows incrementing counter
+- **Confidence:** high
+- **Risks:** None
+
+### PROGRESS-003: Integrate with concurrent fetch
+
+- **Intent:** Progress works correctly with parallel operations
+- **Expected Outcome:** Counter reflects completed (not started) files
+- **Scope:** Thread-safe counter updates
+- **Files:** `src/index.ts`
+- **Dependencies:** PROGRESS-002, CONCURRENT-002
+- **Validation:** Concurrent fetch shows accurate progress
+- **Confidence:** medium
+- **Risks:** Race conditions in counter updates
+
+## Decisions
+
+- **D-001:** Use Unicode spinner chars — wide terminal support
+- **D-002:** Progress to stderr — stdout reserved for output
+
+## Notes
+
+- Keep implementation simple, no external dependencies

--- a/plans/modules/09-shell-completion.aps.md
+++ b/plans/modules/09-shell-completion.aps.md
@@ -1,0 +1,98 @@
+<!-- APS: Anvil Plan Specification -->
+<!-- Executable only if work items exist and status is Ready. -->
+
+# Shell Completion Module
+
+| Scope | Owner | Priority | Status |
+|-------|-------|----------|--------|
+| UX | — | medium | Draft |
+
+## Purpose
+
+Provide shell completion scripts for bash, zsh, and fish. Tab completion dramatically improves CLI discoverability and reduces typing errors.
+
+## In Scope
+
+- Bash completion script
+- Zsh completion script
+- Fish completion script
+- `git-file-fetch completion <shell>` command to output script
+- Installation instructions in docs
+
+## Out of Scope
+
+- Automatic installation
+- PowerShell completion
+- Dynamic completions (e.g., completing repo URLs)
+
+## Interfaces
+
+**Exposes:**
+
+- `git-file-fetch completion bash` — outputs bash completion
+- `git-file-fetch completion zsh` — outputs zsh completion
+- `git-file-fetch completion fish` — outputs fish completion
+
+## Acceptance Criteria
+
+- [ ] `completion bash` outputs valid bash completion script
+- [ ] `completion zsh` outputs valid zsh completion script
+- [ ] `completion fish` outputs valid fish completion script
+- [ ] Tab completes all flags (--dry-run, --force, etc.)
+- [ ] Tab completes commands (update, verify, list, init)
+- [ ] Instructions work on fresh shell setup
+
+## Work Items
+
+### SHELL-001: Add `completion` subcommand
+
+- **Intent:** Output shell completion scripts
+- **Expected Outcome:** `completion bash` prints script
+- **Scope:** Subcommand routing, script output
+- **Files:** `src/index.ts`
+- **Dependencies:** None
+- **Validation:** `completion bash > /dev/null` exits 0
+- **Confidence:** high
+- **Risks:** None
+
+### SHELL-002: Implement bash completion
+
+- **Intent:** Tab completion in bash
+- **Expected Outcome:** Complete script for bash
+- **Scope:** Bash completion syntax
+- **Files:** `src/index.ts` (embedded script)
+- **Dependencies:** SHELL-001
+- **Validation:** Source script, tab completes --dry-run
+- **Confidence:** high
+- **Risks:** None
+
+### SHELL-003: Implement zsh completion
+
+- **Intent:** Tab completion in zsh
+- **Expected Outcome:** Complete script for zsh
+- **Scope:** Zsh completion syntax
+- **Files:** `src/index.ts` (embedded script)
+- **Dependencies:** SHELL-001
+- **Validation:** Source script, tab completes in zsh
+- **Confidence:** medium
+- **Risks:** Zsh completion syntax complexity
+
+### SHELL-004: Implement fish completion
+
+- **Intent:** Tab completion in fish
+- **Expected Outcome:** Complete script for fish
+- **Scope:** Fish completion syntax
+- **Files:** `src/index.ts` (embedded script)
+- **Dependencies:** SHELL-001
+- **Validation:** Source script, tab completes in fish
+- **Confidence:** medium
+- **Risks:** Fish syntax differs significantly
+
+## Decisions
+
+- **D-001:** Embed scripts in source — no separate files to ship
+- **D-002:** Static completions only — no dynamic repo/file completion (complex)
+
+## Notes
+
+- Update docs/getting-started.md with completion setup instructions

--- a/plans/modules/10-list-command.aps.md
+++ b/plans/modules/10-list-command.aps.md
@@ -1,0 +1,89 @@
+<!-- APS: Anvil Plan Specification -->
+<!-- Executable only if work items exist and status is Ready. -->
+
+# List Command Module
+
+| Scope | Owner | Priority | Status |
+|-------|-------|----------|--------|
+| WORKFLOW | — | medium | Draft |
+
+## Purpose
+
+Add a `list` command that displays manifest contents in a human-readable format. Quickly see what external files are tracked without reading JSON.
+
+## In Scope
+
+- Pretty-print manifest entries
+- Show repo, ref, path, destination
+- Show commit SHA (truncated)
+- Support `--json` for machine output
+- Support filtering by repo or path
+
+## Out of Scope
+
+- Interactive selection
+- Manifest editing
+- File status (modified, missing)
+
+## Interfaces
+
+**Depends on:**
+
+- Manifest file — `.git-remote-files.json`
+
+**Exposes:**
+
+- `git-file-fetch list` — show all tracked files
+- `git-file-fetch list --filter <pattern>` — filter entries
+
+## Acceptance Criteria
+
+- [ ] `list` shows all manifest entries in readable format
+- [ ] Output includes repo, ref, path, short SHA
+- [ ] `--json` outputs raw manifest JSON
+- [ ] `--filter` narrows results by pattern
+- [ ] Empty manifest shows helpful message
+- [ ] Exit code 0 always (read-only operation)
+
+## Work Items
+
+### LIST-001: Parse `list` subcommand
+
+- **Intent:** Recognize list command
+- **Expected Outcome:** `git-file-fetch list` invokes handler
+- **Scope:** CLI routing
+- **Files:** `src/index.ts`
+- **Dependencies:** None
+- **Validation:** `list --help` shows list-specific help
+- **Confidence:** high
+- **Risks:** None
+
+### LIST-002: Implement formatted output
+
+- **Intent:** Pretty-print manifest contents
+- **Expected Outcome:** Clean table or list format
+- **Scope:** Output formatting
+- **Files:** `src/index.ts`
+- **Dependencies:** LIST-001
+- **Validation:** `list` shows readable output
+- **Confidence:** high
+- **Risks:** None
+
+### LIST-003: Add `--filter` option
+
+- **Intent:** Filter list by pattern
+- **Expected Outcome:** Only matching entries shown
+- **Scope:** Pattern matching, filtering
+- **Files:** `src/index.ts`
+- **Dependencies:** LIST-002
+- **Validation:** `--filter github` shows only github repos
+- **Confidence:** high
+- **Risks:** None
+
+## Decisions
+
+- **D-001:** Default to pretty format, `--json` for raw — optimized for humans
+
+## Notes
+
+- Consider `list --status` in future to show local file status

--- a/plans/modules/11-init-command.aps.md
+++ b/plans/modules/11-init-command.aps.md
@@ -1,0 +1,84 @@
+<!-- APS: Anvil Plan Specification -->
+<!-- Executable only if work items exist and status is Ready. -->
+
+# Init Command Module
+
+| Scope | Owner | Priority | Status |
+|-------|-------|----------|--------|
+| UX | — | medium | Draft |
+
+## Purpose
+
+Add an `init` command that creates a sample configuration file. Helps users get started quickly with correct syntax and examples.
+
+## In Scope
+
+- Create `.git-file-fetch.json` or `refs.json`
+- Include commented examples
+- Detect if config already exists (don't overwrite)
+- Support `--force` to overwrite
+
+## Out of Scope
+
+- Interactive wizard
+- Fetching files during init
+- Detecting existing manifest
+
+## Interfaces
+
+**Exposes:**
+
+- `git-file-fetch init` — create sample config
+- `git-file-fetch init --force` — overwrite existing
+
+## Acceptance Criteria
+
+- [ ] `init` creates config file with examples
+- [ ] Refuses to overwrite existing file
+- [ ] `--force` overwrites existing file
+- [ ] Created config is valid JSON
+- [ ] Examples use realistic repo URLs
+- [ ] Comments explain config format
+
+## Work Items
+
+### INIT-001: Parse `init` subcommand
+
+- **Intent:** Recognize init command
+- **Expected Outcome:** `git-file-fetch init` invokes handler
+- **Scope:** CLI routing
+- **Files:** `src/index.ts`
+- **Dependencies:** None
+- **Validation:** `init --help` shows init help
+- **Confidence:** high
+- **Risks:** None
+
+### INIT-002: Implement config file creation
+
+- **Intent:** Write sample config file
+- **Expected Outcome:** Valid config file created
+- **Scope:** File writing with template
+- **Files:** `src/index.ts`
+- **Dependencies:** INIT-001
+- **Validation:** Created file parseable by `--config`
+- **Confidence:** high
+- **Risks:** None
+
+### INIT-003: Add existence check and `--force`
+
+- **Intent:** Safe default, explicit override
+- **Expected Outcome:** Refuses overwrite without --force
+- **Scope:** File existence check, force flag
+- **Files:** `src/index.ts`
+- **Dependencies:** INIT-002
+- **Validation:** Second `init` fails, `init --force` succeeds
+- **Confidence:** high
+- **Risks:** None
+
+## Decisions
+
+- **D-001:** Use `.git-file-fetch.json` as default name — branded, discoverable
+
+## Notes
+
+- Template should show both string and object config formats

--- a/plans/modules/12-error-hints.aps.md
+++ b/plans/modules/12-error-hints.aps.md
@@ -1,0 +1,96 @@
+<!-- APS: Anvil Plan Specification -->
+<!-- Executable only if work items exist and status is Ready. -->
+
+# Error Hints Module
+
+| Scope | Owner | Priority | Status |
+|-------|-------|----------|--------|
+| UX | — | medium | Draft |
+
+## Purpose
+
+Enhance error messages with contextual hints and suggested fixes. Transform cryptic errors into actionable guidance.
+
+## In Scope
+
+- "Did you mean...?" suggestions for typos
+- Authentication hints for 401/403 errors
+- Network troubleshooting hints
+- Common mistake detection and correction
+
+## Out of Scope
+
+- Auto-correction (just suggest)
+- Interactive prompts
+- Telemetry on errors
+
+## Interfaces
+
+**Exposes:**
+
+- Enhanced error messages with hints
+- Hint suppression with `--no-hints`
+
+## Acceptance Criteria
+
+- [ ] Auth errors suggest setting GITHUB_TOKEN
+- [ ] 404 errors suggest checking repo URL and ref
+- [ ] Network errors suggest checking connectivity
+- [ ] Typos in flags show "did you mean"
+- [ ] `--no-hints` shows raw errors only
+- [ ] Hints don't clutter `--json` output
+
+## Work Items
+
+### HINTS-001: Add hint infrastructure
+
+- **Intent:** Framework for attaching hints to errors
+- **Expected Outcome:** Errors can include optional hints
+- **Scope:** Error class enhancement
+- **Files:** `src/index.ts`
+- **Dependencies:** None
+- **Validation:** Error with hint shows hint in output
+- **Confidence:** high
+- **Risks:** None
+
+### HINTS-002: Add authentication hints
+
+- **Intent:** Guide users on auth setup
+- **Expected Outcome:** 401/403 includes token setup hint
+- **Scope:** HTTP status detection, auth hints
+- **Files:** `src/index.ts`
+- **Dependencies:** HINTS-001
+- **Validation:** Private repo error shows GITHUB_TOKEN hint
+- **Confidence:** high
+- **Risks:** None
+
+### HINTS-003: Add network troubleshooting hints
+
+- **Intent:** Help debug connectivity issues
+- **Expected Outcome:** Network errors include connectivity hints
+- **Scope:** Error type detection, network hints
+- **Files:** `src/index.ts`
+- **Dependencies:** HINTS-001
+- **Validation:** Timeout error shows network hint
+- **Confidence:** high
+- **Risks:** None
+
+### HINTS-004: Add "did you mean" for flags
+
+- **Intent:** Catch typos in command line flags
+- **Expected Outcome:** `--dryrun` suggests `--dry-run`
+- **Scope:** Levenshtein distance, flag matching
+- **Files:** `src/index.ts`
+- **Dependencies:** HINTS-001
+- **Validation:** Typo'd flag shows suggestion
+- **Confidence:** medium
+- **Risks:** False positives
+
+## Decisions
+
+- **D-001:** Hints to stderr, not stdout — don't pollute machine output
+- **D-002:** Keep hints concise — one actionable sentence
+
+## Notes
+
+- Could add `--verbose` hints with more detail

--- a/plans/modules/13-monorepo-workspaces.aps.md
+++ b/plans/modules/13-monorepo-workspaces.aps.md
@@ -1,0 +1,206 @@
+<!-- APS: Anvil Plan Specification -->
+<!-- Executable only if work items exist and status is Ready. -->
+
+# Monorepo Workspaces Module
+
+| Scope | Owner | Priority | Status |
+|-------|-------|----------|--------|
+| SCALE | — | high | Draft |
+
+## Purpose
+
+Enable workspace-aware configuration for monorepos where different packages need different external dependencies. Support config inheritance, workspace-wide operations, and integration with popular monorepo tools (Nx, Turborepo, pnpm workspaces).
+
+## In Scope
+
+- Workspace detection (package.json workspaces, pnpm-workspace.yaml, nx.json)
+- Config inheritance (root + package-level configs)
+- Workspace-wide commands (`--workspace` or `-w` flag)
+- Per-package manifest files
+- Selective package operations (`--filter <package>`)
+- Nx/Turborepo executor integration
+
+## Out of Scope
+
+- Workspace creation/scaffolding
+- Package manager operations
+- Dependency resolution between packages
+- Publishing workspace packages
+
+## Interfaces
+
+**Depends on:**
+
+- Workspace config files — `package.json`, `pnpm-workspace.yaml`, `nx.json`
+- Per-package configs — `packages/*/git-file-fetch.json`
+- Root config — `.git-file-fetch.json` (inherited)
+
+**Exposes:**
+
+- `git-file-fetch -w` — run across all workspace packages
+- `git-file-fetch --filter <pkg>` — run for specific package(s)
+- Config inheritance — package configs extend root config
+- Per-package manifests — `packages/pkg-a/.git-remote-files.json`
+
+## Boundary Rules
+
+- WORKSPACE must not modify package manager configs
+- WORKSPACE must respect .gitignore and workspace exclusions
+- WORKSPACE operations must be parallelizable per-package
+
+## Acceptance Criteria
+
+- [ ] Auto-detects workspace root from any subdirectory
+- [ ] `-w` flag runs operation across all packages
+- [ ] Package configs inherit from root config
+- [ ] `--filter` accepts package names or glob patterns
+- [ ] Each package gets its own manifest file
+- [ ] Works with npm, pnpm, yarn, and Nx workspaces
+- [ ] `--json` output groups results by package
+- [ ] Exit code reflects worst per-package result
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Many packages = slow operations | Leverage concurrent-fetch, parallel per-package |
+| Config conflicts between root and package | Clear precedence: package overrides root |
+| Large workspace discovery slow | Cache workspace structure, watch for changes |
+| Different tools have different conventions | Abstract workspace detection, support major tools |
+
+## Work Items
+
+### MONO-001: Implement workspace detection
+
+- **Intent:** Find workspace root and enumerate packages
+- **Expected Outcome:** `detectWorkspace()` returns root path and package list
+- **Scope:** Parse package.json workspaces, pnpm-workspace.yaml, nx.json
+- **Non-scope:** Lerna, Rush (future)
+- **Files:** `src/index.ts` or new `src/workspace.ts`
+- **Dependencies:** None
+- **Validation:** Detects packages in sample monorepo
+- **Confidence:** high
+- **Risks:** Edge cases in glob patterns
+
+### MONO-002: Implement config inheritance
+
+- **Intent:** Package configs extend root config
+- **Expected Outcome:** Merged config with package values taking precedence
+- **Scope:** Config loading, merging logic
+- **Non-scope:** Complex merge strategies (arrays, deep merge)
+- **Files:** `src/index.ts`
+- **Dependencies:** MONO-001
+- **Validation:** Package config overrides root value
+- **Confidence:** high
+- **Risks:** None
+
+### MONO-003: Add `-w` workspace flag
+
+- **Intent:** Run operations across all workspace packages
+- **Expected Outcome:** Command executes for each package sequentially
+- **Scope:** CLI flag, iteration over packages
+- **Non-scope:** Parallel execution (use with concurrent-fetch)
+- **Files:** `src/index.ts`
+- **Dependencies:** MONO-001
+- **Validation:** `git-file-fetch update -w` updates all packages
+- **Confidence:** high
+- **Risks:** None
+
+### MONO-004: Add `--filter` package selector
+
+- **Intent:** Run operations for specific packages only
+- **Expected Outcome:** Only matching packages processed
+- **Scope:** Filter parsing, package name matching, glob support
+- **Non-scope:** Complex query syntax
+- **Files:** `src/index.ts`
+- **Dependencies:** MONO-003
+- **Validation:** `--filter pkg-a` only processes pkg-a
+- **Confidence:** high
+- **Risks:** None
+
+### MONO-005: Implement per-package manifests
+
+- **Intent:** Each package tracks its own external files
+- **Expected Outcome:** Manifest in each package directory
+- **Scope:** Manifest path resolution per package
+- **Non-scope:** Shared/global manifest option
+- **Files:** `src/index.ts`
+- **Dependencies:** MONO-003
+- **Validation:** Fetch in pkg-a creates pkg-a/.git-remote-files.json
+- **Confidence:** high
+- **Risks:** None
+
+### MONO-006: Add workspace-aware JSON output
+
+- **Intent:** Group results by package in JSON mode
+- **Expected Outcome:** `{ "packages": { "pkg-a": {...}, "pkg-b": {...} } }`
+- **Scope:** Output structure for workspace operations
+- **Non-scope:** Custom formatters
+- **Files:** `src/index.ts`
+- **Dependencies:** MONO-003
+- **Validation:** `-w --json` shows per-package results
+- **Confidence:** high
+- **Risks:** None
+
+### MONO-007: Nx executor workspace support
+
+- **Intent:** Nx executor respects workspace context
+- **Expected Outcome:** Executor runs in correct package context
+- **Scope:** Update executor to pass workspace flags
+- **Non-scope:** Nx generator
+- **Files:** `plugin/executors/fetch/executor.ts`
+- **Dependencies:** MONO-003
+- **Validation:** `nx run pkg-a:fetch` uses pkg-a config
+- **Confidence:** medium
+- **Risks:** Nx context API changes
+
+## Configuration Examples
+
+### Root Config (`.git-file-fetch.json`)
+```json
+{
+  "defaults": {
+    "timeout": 30000,
+    "retries": 3
+  },
+  "refs": [
+    "https://github.com/shared/utils.git@main:LICENSE"
+  ]
+}
+```
+
+### Package Config (`packages/pkg-a/.git-file-fetch.json`)
+```json
+{
+  "extends": "../../.git-file-fetch.json",
+  "refs": [
+    "https://github.com/specific/lib.git@v2.0:src/helper.ts"
+  ]
+}
+```
+
+### Resulting Merged Config for pkg-a
+```json
+{
+  "defaults": {
+    "timeout": 30000,
+    "retries": 3
+  },
+  "refs": [
+    "https://github.com/shared/utils.git@main:LICENSE",
+    "https://github.com/specific/lib.git@v2.0:src/helper.ts"
+  ]
+}
+```
+
+## Decisions
+
+- **D-001:** Package configs override root — explicit wins over inherited
+- **D-002:** Per-package manifests by default — isolation over sharing
+- **D-003:** Support major tools only — npm/pnpm/yarn workspaces + Nx
+
+## Notes
+
+- Consider `--hoist` flag to put all manifests in root (optional)
+- Turborepo integration via turbo.json tasks
+- Future: `git-file-fetch workspace init` to scaffold configs

--- a/plugin/executors.json
+++ b/plugin/executors.json
@@ -4,7 +4,7 @@
     "fetch": {
       "implementation": "./executors/fetch/executor.js",
       "schema": "./executors/fetch/schema.json",
-      "description": "Run @arkahna/git-file-fetch via Nx"
+      "description": "Run git-file-fetch via Nx"
     }
   }
 }

--- a/plugin/executors/fetch/executor.js
+++ b/plugin/executors/fetch/executor.js
@@ -1,7 +1,7 @@
 import { execSync } from 'child_process';
 export default async function runExecutor(options, _context) {
     try {
-        const command = `npx @arkahna/git-file-fetch ${options.args}`;
+        const command = `npx git-file-fetch ${options.args}`;
         console.log(`Running: ${command}`);
         execSync(command, { stdio: 'inherit' });
         return { success: true };

--- a/plugin/executors/fetch/executor.ts
+++ b/plugin/executors/fetch/executor.ts
@@ -16,7 +16,7 @@ export default async function runExecutor(
   _context: NxExecutorContext,
 ) {
   try {
-    const command = `npx @arkahna/git-file-fetch ${options.args}`;
+    const command = `npx git-file-fetch ${options.args}`;
     console.log(`Running: ${command}`);
     execSync(command, { stdio: 'inherit' });
     return { success: true };

--- a/plugin/executors/fetch/schema.json
+++ b/plugin/executors/fetch/schema.json
@@ -4,7 +4,7 @@
   "properties": {
     "args": {
       "type": "string",
-      "description": "Arguments to pass to the @arkahna/git-file-fetch CLI"
+      "description": "Arguments to pass to the git-file-fetch CLI"
     }
   },
   "required": ["args"]

--- a/plugin/project.json
+++ b/plugin/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@arkahna/git-file-fetch",
+  "name": "git-file-fetch",
   "targets": {
     "fetch": {
       "executor": "./plugin/executors/fetch:default",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 
-// @arkahna/git-file-fetch
+// git-file-fetch
 // Fetch specific file(s) from remote Git repos and drop them into your project.
 // Tracks origin in .git-remote-files.json for reproducibility.
+
+const VERSION = '0.1.0';
 
 import { execFileSync } from 'child_process';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
@@ -63,10 +65,10 @@ function createLogger(quiet: boolean, verbose: boolean) {
 
 function printHelp() {
   const usage = `
-@arkahna/git-file-fetch
+git-file-fetch v${VERSION}
 
 Usage:
-  @arkahna/git-file-fetch '<repo.git>@<ref>:<path>' [more...] [--dry-run] [--force] [--out <dir>] [--cwd <dir>] [--manifest <path>] [--max-bytes <n>] [--config <file>] [--timeout-ms <n>] [--retries <n>] [--retry-backoff-ms <n>] [--eject] [--json] [--quiet] [--verbose]
+  git-file-fetch '<repo.git>@<ref>:<path>' [more...] [--dry-run] [--force] [--out <dir>] [--cwd <dir>] [--manifest <path>] [--max-bytes <n>] [--config <file>] [--timeout-ms <n>] [--retries <n>] [--retry-backoff-ms <n>] [--eject] [--json] [--quiet] [--verbose]
 
 Options:
   --dry-run           Simulate only; do not write files or update the manifest
@@ -83,13 +85,14 @@ Options:
   --json              Machine-readable JSON output with per-item results
   --quiet             Suppress normal logs (errors still printed)
   --verbose           Print verbose logs for debugging
+  -v, --version       Show version number and exit
   -h, --help          Show this help and exit
 
 Examples:
-  npx @arkahna/git-file-fetch "https://github.com/user/repo.git@main:src/utils/logger.ts"
-  npx @arkahna/git-file-fetch "https://github.com/user/repo.git@v1.2.3:LICENSE" --force
-  npx @arkahna/git-file-fetch --out third_party "https://github.com/user/repo.git@main:tools/script.sh"
-  npx @arkahna/git-file-fetch --config refs.json --out vendor --json
+  npx git-file-fetch "https://github.com/user/repo.git@main:src/utils/logger.ts"
+  npx git-file-fetch "https://github.com/user/repo.git@v1.2.3:LICENSE" --force
+  npx git-file-fetch --out third_party "https://github.com/user/repo.git@main:tools/script.sh"
+  npx git-file-fetch --config refs.json --out vendor --json
 
 Exit codes:
   0  Success
@@ -204,7 +207,7 @@ function updateManifest(manifestPath: string, remote: RemoteFile) {
 }
 
 function fsTempDir(): string {
-  const dir = join(tmpdir(), `arkahna-git-file-fetch-${Date.now()}`);
+  const dir = join(tmpdir(), `git-file-fetch-${Date.now()}`);
   mkdirSync(dir);
   return dir;
 }
@@ -424,6 +427,7 @@ function fetchFileMinimal(
 function main() {
   const argv = process.argv.slice(2);
   const showHelp = argv.includes('-h') || argv.includes('--help');
+  const showVersion = argv.includes('-v') || argv.includes('--version');
   const dryRun = argv.includes('--dry-run');
   const force = argv.includes('--force');
   const jsonOutput = argv.includes('--json');
@@ -486,6 +490,11 @@ function main() {
       : (envBackoff ?? 500);
 
   const configFlag = getFlagValue(argv, 'config');
+
+  if (showVersion) {
+    console.log(VERSION);
+    process.exit(0);
+  }
 
   if (showHelp) {
     printHelp();


### PR DESCRIPTION
- Rename package from @arkahna-npm/git-file-fetch to git-file-fetch
- Update author to Joshua Boys and update repository URLs
- Remove all Arkahna references from source code, docs, and config
- Add --version flag to CLI
- Update contact info in security and code of conduct docs
- Simplify README by removing pre-release testing instructions
- Clean up .npmrc for public npm registry